### PR TITLE
Add pyproject and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# nixie
+
+`nixie` is a simple command line tool that validates Mermaid diagrams embedded in Markdown files.
+
+The CLI scans each provided file (or directory) for `mermaid` code blocks and
+invokes `mermaid-cli` to verify that the diagrams can be rendered without
+errors.
+
+## Usage
+
+```bash
+nixie path/to/file.md
+```
+
+Use `--concurrency` to control how many diagrams are processed in parallel. The tool relies on
+Node.js and `@mermaid-js/mermaid-cli` being available on your system.
+
+## Development
+
+Development dependencies are managed via `pyproject.toml`. After installing
+[uv](https://github.com/astral-sh/uv), run:
+
+```bash
+uv sync --include dev
+```
+
+This installs linters and test tools such as Ruff, Pyright and pytest.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nixie
 
-`nixie` is a simple command line tool that validates Mermaid diagrams embedded in Markdown files.
+`nixie` is a simple command-line tool that validates Mermaid diagrams embedded in Markdown files.
 
 The CLI scans each provided file (or directory) for `mermaid` code blocks and
 invokes `mermaid-cli` to verify that the diagrams can be rendered without

--- a/nixie/__init__.py
+++ b/nixie/__init__.py
@@ -1,1 +1,5 @@
+"""nixie package."""
 
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -210,6 +210,11 @@ def parse_args():
     return parser.parse_args()
 
 
-if __name__ == "__main__":
+def cli() -> None:
+    """Entry point for the ``nixie`` console script."""
     parsed = parse_args()
     sys.exit(asyncio.run(main(parsed.paths, parsed.concurrency)))
+
+
+if __name__ == "__main__":
+    cli()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+[project]
+name = "nixie"
+version = "0.1.0"
+description = "Validate Mermaid diagrams in Markdown files"
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "ISC" }
+authors = [{ name = "Payton McIntosh", email = "pmcintosh@df12.net" }]
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: ISC License",
+  "Operating System :: OS Independent",
+]
+
+[project.optional-dependencies]
+dev = [
+  "ruff",
+  "pyright",
+  "pytest",
+]
+
+[project.scripts]
+nixie = "nixie.cli:cli"
+
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.uv]
+package = true


### PR DESCRIPTION
## Summary
- configure project metadata in `pyproject.toml`
- add a basic README
- expose a `nixie` console script
- declare package version

## Testing
- `ruff format --quiet`
- `ruff check --quiet`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845f4f600ac8322bda1f15fd248a8bf

## Summary by Sourcery

Configure packaging via pyproject.toml, set up the console script, declare the package version, refactor the CLI entry point, and add a README

New Features:
- Add pyproject.toml for project metadata, dependencies, and build configuration
- Expose the `nixie` console script entry point via project scripts
- Declare and expose the package version constant

Enhancements:
- Refactor CLI entry logic into a dedicated `cli()` function

Documentation:
- Add a basic README with usage and development instructions