### PR TITLE
Add tests for CLI behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,10 @@ uv sync --include dev
 ```
 
 This installs linters and test tools such as Ruff, Pyright and pytest.
+
+Before running the test suite, install the project in editable mode so the
+package can be imported:
+
+```bash
+pip install -e .
+```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Development dependencies are managed via `pyproject.toml`. After installing
 uv sync --include dev
 ```
 
-This installs linters and test tools such as Ruff, Pyright and pytest.
+This installs linters and test tools such as Ruff, Pyright, pytest and
+pytest-asyncio.
 
 Before running the test suite, install the project in editable mode so the
 package can be imported:

--- a/nixie/unittests/test_parse_blocks.py
+++ b/nixie/unittests/test_parse_blocks.py
@@ -1,0 +1,25 @@
+import pytest
+
+from nixie.cli import parse_blocks
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "```mermaid\nA-->B\n```",
+        "``` mermaid\nA-->B\n``` ",
+        "```mermaid   \nA-->B\n```   ",
+        "```   mermaid   \nA-->B\n```",
+    ],
+)
+def test_parse_blocks_variations(text: str) -> None:
+    assert parse_blocks(text) == ["A-->B"]
+
+
+def test_parse_blocks_multiple() -> None:
+    content = "```mermaid\nA-->B\n```\n\n```mermaid\nC-->D\n```"
+    assert parse_blocks(content) == ["A-->B", "C-->D"]
+
+
+def test_parse_blocks_none() -> None:
+    assert parse_blocks("No diagrams here") == []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.uv]
 package = true
+
+[tool.pytest.ini_options]
+testpaths = ["nixie/unittests", "tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dev = [
   "ruff",
   "pyright",
   "pytest",
+  "pytest-asyncio",
 ]
 
 [project.scripts]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,0 @@
-from __future__ import annotations
-
-import sys
-from pathlib import Path
-
-# Ensure project root is on sys.path for tests
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path for tests
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,27 @@
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+@pytest.fixture
+def stub_render(monkeypatch) -> AsyncMock:
+    async def side_effect(
+        block: str,
+        tmpdir: Path,
+        cfg_path: Path,
+        path: Path,
+        idx: int,
+        semaphore: asyncio.Semaphore,
+        timeout: float = 30.0,
+    ) -> bool:
+        if "invalid" in block.lower():
+            print("Parse error on line 1: INVALID", file=sys.stderr)
+            return False
+        return True
+
+    mock = AsyncMock(side_effect=side_effect)
+    monkeypatch.setattr("nixie.cli.render_block", mock)
+    return mock

--- a/tests/integration/test_cli_behavior.py
+++ b/tests/integration/test_cli_behavior.py
@@ -1,32 +1,9 @@
-import asyncio
-import sys
 from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
 
 from nixie.cli import main
-
-
-@pytest.fixture
-def stub_render(monkeypatch) -> AsyncMock:
-    async def side_effect(
-        block: str,
-        tmpdir: Path,
-        cfg_path: Path,
-        path: Path,
-        idx: int,
-        semaphore: asyncio.Semaphore,
-        timeout: float = 30.0,
-    ) -> bool:
-        if "invalid" in block.lower():
-            print("Parse error on line 1: INVALID", file=sys.stderr)
-            return False
-        return True
-
-    mock = AsyncMock(side_effect=side_effect)
-    monkeypatch.setattr("nixie.cli.render_block", mock)
-    return mock
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_cli_behavior.py
+++ b/tests/integration/test_cli_behavior.py
@@ -1,0 +1,77 @@
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from nixie.cli import main
+
+
+@pytest.fixture(autouse=True)
+def stub_render(monkeypatch):
+    async def fake_render_block(
+        block: str,
+        tmpdir: Path,
+        cfg_path: Path,
+        path: Path,
+        idx: int,
+        semaphore: asyncio.Semaphore,
+        timeout: float = 30.0,
+    ) -> bool:
+        return "invalid" not in block.lower()
+
+    monkeypatch.setattr("nixie.cli.render_block", fake_render_block)
+
+
+def test_single_file_success(tmp_path: Path) -> None:
+    md = tmp_path / "good.md"
+    md.write_text("""```mermaid
+A-->B
+```""")
+    exit_code = asyncio.run(main([md], 2))
+    assert exit_code == 0
+
+
+def test_single_file_failure(tmp_path: Path) -> None:
+    md = tmp_path / "bad.md"
+    md.write_text("""```mermaid
+INVALID
+```""")
+    exit_code = asyncio.run(main([md], 2))
+    assert exit_code == 1
+
+
+def test_directory_and_multiple_files(tmp_path: Path) -> None:
+    dir_path = tmp_path / "docs"
+    dir_path.mkdir()
+    (dir_path / "one.md").write_text("""```mermaid
+A-->B
+```""")
+    (dir_path / "two.md").write_text("""```mermaid
+invalid diagram
+```""")
+    extra = tmp_path / "extra.md"
+    extra.write_text("Just text")
+    exit_code = asyncio.run(main([dir_path, extra], 2))
+    assert exit_code == 1
+
+
+def test_multiple_diagrams(tmp_path: Path) -> None:
+    md = tmp_path / "multi.md"
+    md.write_text(
+        """```mermaid
+A-->B
+```
+
+```mermaid
+invalid
+```"""
+    )
+    exit_code = asyncio.run(main([md], 2))
+    assert exit_code == 1
+
+
+def test_no_diagrams(tmp_path: Path) -> None:
+    md = tmp_path / "none.md"
+    md.write_text("No diagrams here")
+    exit_code = asyncio.run(main([md], 2))
+    assert exit_code == 0

--- a/tests/integration/test_cli_behavior.py
+++ b/tests/integration/test_cli_behavior.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 from pathlib import Path
 
 import pytest
@@ -6,7 +7,7 @@ import pytest
 from nixie.cli import main
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def stub_render(monkeypatch):
     async def fake_render_block(
         block: str,
@@ -17,30 +18,38 @@ def stub_render(monkeypatch):
         semaphore: asyncio.Semaphore,
         timeout: float = 30.0,
     ) -> bool:
-        return "invalid" not in block.lower()
+        if "invalid" in block.lower():
+            print("Parse error on line 1: INVALID", file=sys.stderr)
+            return False
+        return True
 
     monkeypatch.setattr("nixie.cli.render_block", fake_render_block)
+    return fake_render_block
 
 
-def test_single_file_success(tmp_path: Path) -> None:
+def test_single_file_success(tmp_path: Path, stub_render, capsys) -> None:
     md = tmp_path / "good.md"
     md.write_text("""```mermaid
 A-->B
 ```""")
     exit_code = asyncio.run(main([md], 2))
+    captured = capsys.readouterr()
     assert exit_code == 0
+    assert captured.err == ""
 
 
-def test_single_file_failure(tmp_path: Path) -> None:
+def test_single_file_failure(tmp_path: Path, stub_render, capsys) -> None:
     md = tmp_path / "bad.md"
     md.write_text("""```mermaid
 INVALID
 ```""")
     exit_code = asyncio.run(main([md], 2))
+    captured = capsys.readouterr()
     assert exit_code == 1
+    assert "Parse error" in captured.err
 
 
-def test_directory_and_multiple_files(tmp_path: Path) -> None:
+def test_directory_and_multiple_files(tmp_path: Path, stub_render, capsys) -> None:
     dir_path = tmp_path / "docs"
     dir_path.mkdir()
     (dir_path / "one.md").write_text("""```mermaid
@@ -52,10 +61,12 @@ invalid diagram
     extra = tmp_path / "extra.md"
     extra.write_text("Just text")
     exit_code = asyncio.run(main([dir_path, extra], 2))
+    captured = capsys.readouterr()
     assert exit_code == 1
+    assert "Parse error" in captured.err
 
 
-def test_multiple_diagrams(tmp_path: Path) -> None:
+def test_multiple_diagrams(tmp_path: Path, stub_render, capsys) -> None:
     md = tmp_path / "multi.md"
     md.write_text(
         """```mermaid
@@ -67,11 +78,15 @@ invalid
 ```"""
     )
     exit_code = asyncio.run(main([md], 2))
+    captured = capsys.readouterr()
     assert exit_code == 1
+    assert "Parse error" in captured.err
 
 
-def test_no_diagrams(tmp_path: Path) -> None:
+def test_no_diagrams(tmp_path: Path, stub_render, capsys) -> None:
     md = tmp_path / "none.md"
     md.write_text("No diagrams here")
     exit_code = asyncio.run(main([md], 2))
+    captured = capsys.readouterr()
     assert exit_code == 0
+    assert captured.err == ""


### PR DESCRIPTION
## Summary
- add unit tests for mermaid block parsing covering various markdown fence styles
- add behavioral tests verifying CLI success and failure scenarios
- ensure project root is on `sys.path` in tests

## Testing
- `ruff format --quiet .`
- `ruff check --quiet .`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845f7cc421883228cf53ca3993d43b2

## Summary by Sourcery

Add comprehensive unit and integration tests for CLI behavior and mermaid block parsing, update test dependencies and configuration, and improve README guidance.

Build:
- Add pytest-asyncio to dev dependencies in pyproject.toml and configure pytest testpaths in pytest.ini options.

Documentation:
- Update README to include pytest-asyncio in dev dependencies and add instructions to install the package in editable mode for testing.

Tests:
- Add unit tests for parse_blocks covering multiple fence style variations and no-diagram cases.
- Add integration tests for CLI behavior covering success, parse failures, multi-file, and empty scenarios using a stubbed renderer fixture.