### PR TITLE
Add empty string case for parse_blocks

### DIFF
--- a/nixie/unittests/test_parse_blocks.py
+++ b/nixie/unittests/test_parse_blocks.py
@@ -23,3 +23,7 @@ def test_parse_blocks_multiple() -> None:
 
 def test_parse_blocks_none() -> None:
     assert parse_blocks("No diagrams here") == []
+
+
+def test_parse_blocks_empty() -> None:
+    assert parse_blocks("") == []


### PR DESCRIPTION
## Summary
- add a unit test for parse_blocks handling an empty string

## Testing
- `pyright`
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68461fe1f51483228394613ad022e560

## Summary by Sourcery

Tests:
- Add test_parse_blocks_empty to assert parse_blocks("") returns an empty list.