### PR TITLE
Add bun fallback for mermaid CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ## Requirements
 
 - Python 3.11+
-- Node.js with `npx` and `@mermaid-js/mermaid-cli`
+- Node.js with `npx` or Bun with `bun x --bun` and `@mermaid-js/mermaid-cli`
 
 ## Installation
 

--- a/nixie/unittests/test_get_mmdc_cmd.py
+++ b/nixie/unittests/test_get_mmdc_cmd.py
@@ -1,0 +1,41 @@
+import shutil
+from pathlib import Path
+
+import pytest
+
+from nixie.cli import get_mmdc_cmd
+
+
+@pytest.fixture()
+def sample_paths(tmp_path: Path) -> tuple[Path, Path, Path]:
+    mmd = tmp_path / "diagram.mmd"
+    svg = tmp_path / "diagram.svg"
+    cfg = tmp_path / "cfg.json"
+    return mmd, svg, cfg
+
+
+def test_get_mmdc_cmd_with_bun(
+    monkeypatch, sample_paths: tuple[Path, Path, Path]
+) -> None:
+    mmd, svg, cfg = sample_paths
+
+    def which(cmd: str) -> str | None:
+        if cmd == "bun":
+            return "/usr/bin/bun"
+        return None
+
+    monkeypatch.setattr(shutil, "which", which)
+
+    cmd = get_mmdc_cmd(mmd, svg, cfg)
+    assert cmd[:3] == ["bun", "x", "--bun"]
+
+
+def test_get_mmdc_cmd_with_npx(
+    monkeypatch, sample_paths: tuple[Path, Path, Path]
+) -> None:
+    mmd, svg, cfg = sample_paths
+
+    monkeypatch.setattr(shutil, "which", lambda cmd: None)
+
+    cmd = get_mmdc_cmd(mmd, svg, cfg)
+    assert cmd[:4] == ["npx", "--yes", "@mermaid-js/mermaid-cli", "mmdc"]


### PR DESCRIPTION
## Summary
- prefer `bun x --bun` when available for rendering diagrams
- document bun as an alternative runtime
- test command generation with and without bun
- use `match`/`case` when building the CLI command
- fix base command initialization in match/case

## Testing
- `ruff format nixie/cli.py nixie/unittests/test_get_mmdc_cmd.py`
- `ruff check nixie/cli.py nixie/unittests/test_get_mmdc_cmd.py`
- `pyright nixie/cli.py nixie/unittests/test_get_mmdc_cmd.py`
- `pytest -q`
- `markdownlint README.md`


------
https://chatgpt.com/codex/tasks/task_e_68493acc2ef08322830c335659343e74