### PR TITLE
Group CLI output by file for multi-path runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ nixie [--concurrency N] FILE [FILE...]
 to the number of CPU cores or `4` if this cannot be determined). Paths can be
 files or directories.
 
+When multiple files are provided, nixie prints markers that show where the
+output for each file starts and ends:
+
+```text
+==> path/to/file.md
+<== path/to/file.md
+```
+
 Example:
 
 ```bash

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -180,16 +180,17 @@ async def main(paths, max_concurrent):
     """Main entry point."""
     semaphore = asyncio.Semaphore(max_concurrent)
     with create_puppeteer_config() as cfg_path:
-        collected_files = collect_markdown_files(paths)
-        tasks = [check_file(p, cfg_path, semaphore) for p in collected_files]
-        results = await asyncio.gather(*tasks, return_exceptions=True)
         all_success = True
-        for result in results:
-            if isinstance(result, Exception):
-                print(f"Validation task raised an exception: {result}")
+        for path in collect_markdown_files(paths):
+            print(f"==> {path}")
+            try:
+                success = await check_file(path, cfg_path, semaphore)
+            except Exception as exc:  # pragma: no cover - unexpected
+                print(f"Validation task raised an exception: {exc}")
+                success = False
+            if not success:
                 all_success = False
-            elif not result:
-                all_success = False
+            print(f"<== {path}")
         return 0 if all_success else 1
 
 

--- a/tests/integration/test_cli_behavior.py
+++ b/tests/integration/test_cli_behavior.py
@@ -103,10 +103,55 @@ async def test_cli_marks_file_boundaries(
     captured = capsys.readouterr()
 
     assert exit_code == 0
-    expected_lines = [
+    lines = captured.out.splitlines()
+    markers = [
         f"==> {file_a}",
         f"<== {file_a}",
         f"==> {file_b}",
         f"<== {file_b}",
     ]
-    assert captured.out.splitlines() == expected_lines
+    for marker in markers:
+        assert lines.count(marker) == 1
+    positions = [lines.index(marker) for marker in markers]
+    assert positions == sorted(positions)
+
+
+@pytest.mark.asyncio
+async def test_cli_handles_file_processing_error(
+    tmp_path: Path,
+    stub_render: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    file_a = tmp_path / "a.md"
+    file_b = tmp_path / "b.md"
+    file_a.write_text("```mermaid\nA-->B\n```")
+    file_b.write_text("```mermaid\nA-->B\n```")
+
+    from nixie import cli as cli_module
+
+    original_check_file = cli_module.check_file
+
+    async def mock_check_file(path: Path, *args, **kwargs) -> bool:
+        if path == file_b:
+            raise ValueError("Simulated processing error")
+        return await original_check_file(path, *args, **kwargs)
+
+    monkeypatch.setattr(cli_module, "check_file", mock_check_file)
+
+    exit_code = await main([file_a, file_b], 2)
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    lines = captured.out.splitlines()
+    markers = [
+        f"==> {file_a}",
+        f"<== {file_a}",
+        f"==> {file_b}",
+        f"<== {file_b}",
+    ]
+    for marker in markers:
+        assert lines.count(marker) == 1
+    positions = [lines.index(marker) for marker in markers]
+    assert positions == sorted(positions)
+    assert "Simulated processing error" in captured.out

--- a/tests/integration/test_cli_behavior.py
+++ b/tests/integration/test_cli_behavior.py
@@ -88,3 +88,25 @@ async def test_cli_behavior(
     }
     expected = {(Path(p), i) for p, i in expected_calls}
     assert actual == expected
+
+
+@pytest.mark.asyncio
+async def test_cli_marks_file_boundaries(
+    tmp_path: Path, stub_render: AsyncMock, capsys: pytest.CaptureFixture[str]
+) -> None:
+    file_a = tmp_path / "a.md"
+    file_b = tmp_path / "b.md"
+    file_a.write_text("```mermaid\nA-->B\n```")
+    file_b.write_text("No diagrams here")
+
+    exit_code = await main([file_a, file_b], 2)
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    expected_lines = [
+        f"==> {file_a}",
+        f"<== {file_a}",
+        f"==> {file_b}",
+        f"<== {file_b}",
+    ]
+    assert captured.out.splitlines() == expected_lines


### PR DESCRIPTION
## Summary
- group CLI results by file to avoid interleaved output when validating multiple paths
- document file-level start and end markers
- test that multi-file runs delimit output per file

## Testing
- `ruff check nixie/cli.py tests/integration/test_cli_behavior.py`
- `pyright`
- `markdownlint README.md`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fd44b5c088322ab82f42e5b91e519

## Summary by Sourcery

Group CLI output by file with start and end markers, update documentation, and add an integration test for boundary markers

Enhancements:
- Group CLI results per file with start and end markers to avoid interleaved output during multi-file runs
- Refactor main to process and report on each file sequentially

Documentation:
- Document file-level start and end markers in the README

Tests:
- Add integration test to verify file-level boundary markers in CLI output