### PR TITLE
Document render_block verbose parameter

### DIFF
--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -113,6 +113,7 @@ async def render_block(
     path: Path,
     idx: int,
     semaphore: asyncio.Semaphore,
+    verbose: bool | None = None,
     timeout: float = 30.0,
 ) -> bool:
     """Render a single mermaid block using the CLI asynchronously.
@@ -131,6 +132,10 @@ async def render_block(
         Index of the block within ``path``.
     semaphore
         Limits concurrent CLI invocations.
+    verbose
+        If ``True``, log the CLI command used to render the block. If ``False``,
+        suppress it. When ``None`` (default), log only if the logger is set to
+        ``INFO`` level.
     timeout
         Maximum time in seconds to wait for the CLI to finish.
 
@@ -141,8 +146,8 @@ async def render_block(
 
     Notes
     -----
-    The command line used for rendering is logged at ``INFO`` level. Run the
-    CLI with ``--verbose`` to display these commands.
+    When command logging is enabled, the command line used for rendering is
+    logged at ``INFO`` level.
     """
     mmd = tmpdir / f"{path.stem}_{idx}.mmd"
     svg = mmd.with_suffix(".svg")
@@ -151,7 +156,13 @@ async def render_block(
         mmd.write_text(block)
 
         cmd = get_mmdc_cmd(mmd, svg, cfg_path)
-        logging.getLogger(__name__).info(shlex.join(cmd))
+        log_cmd = (
+            verbose
+            if verbose is not None
+            else logging.getLogger(__name__).isEnabledFor(logging.INFO)
+        )
+        if log_cmd:
+            logging.getLogger(__name__).info(shlex.join(cmd))
         cli = cmd[0]
 
         async with semaphore:

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -119,36 +119,24 @@ async def render_block(
 ) -> bool:
     """Render a single mermaid block using the CLI asynchronously.
 
-    Parameters
-    ----------
-    block
-        Mermaid code block to render.
-    tmpdir
-        Temporary directory for intermediate files.
-    cfg_path
-        Path to the Puppeteer configuration file.
-    path
-        Markdown file containing the block.
-    idx
-        Index of the block within ``path``.
-    semaphore
-        Limits concurrent CLI invocations.
-    verbose
-        If ``True``, log the CLI command used to render the block. If ``False``,
-        suppress it. When ``None`` (default), log only if the logger is set to
-        ``INFO`` level.
-    timeout
-        Maximum time in seconds to wait for the CLI to finish.
+    Args:
+        block: Mermaid code block to render.
+        tmpdir: Temporary directory for intermediate files.
+        cfg_path: Path to the Puppeteer configuration file.
+        path: Markdown file containing the block.
+        idx: Index of the block within ``path``.
+        semaphore: Limits concurrent CLI invocations.
+        verbose: If ``True``, log the CLI command used to render the block. If
+            ``False``, suppress it. When ``None`` (default), log only if the
+            logger is set to ``INFO`` level.
+        timeout: Maximum time in seconds to wait for the CLI to finish.
 
-    Returns
-    -------
-    bool
+    Returns:
         ``True`` on success, ``False`` otherwise.
 
-    Notes
-    -----
-    When command logging is enabled, the command line used for rendering is
-    logged at ``INFO`` level.
+    Notes:
+        When command logging is enabled, the command line used for rendering is
+        logged at ``INFO`` level.
     """
     mmd = tmpdir / f"{path.stem}_{idx}.mmd"
     svg = mmd.with_suffix(".svg")

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -113,6 +113,7 @@ async def render_block(
     path: Path,
     idx: int,
     semaphore: asyncio.Semaphore,
+    *,
     verbose: bool | None = None,
     timeout: float = 30.0,
 ) -> bool:
@@ -156,13 +157,12 @@ async def render_block(
         mmd.write_text(block)
 
         cmd = get_mmdc_cmd(mmd, svg, cfg_path)
-        log_cmd = (
-            verbose
-            if verbose is not None
-            else logging.getLogger(__name__).isEnabledFor(logging.INFO)
+        logger = logging.getLogger(__name__)
+        should_log = (
+            verbose if verbose is not None else logger.isEnabledFor(logging.INFO)
         )
-        if log_cmd:
-            logging.getLogger(__name__).info(shlex.join(cmd))
+        if should_log:
+            logger.info(shlex.join(cmd))
         cli = cmd[0]
 
         async with semaphore:


### PR DESCRIPTION
## Summary
- document the optional `verbose` flag for `render_block`
- support conditional command logging based on the flag

## Testing
- `ruff check nixie/cli.py`
- `pyright`
- `python -m pytest`

closes #8

------
https://chatgpt.com/codex/tasks/task_e_6893aabe5ac88322865380fee0f1e9b3

## Summary by Sourcery

Introduce an optional verbose flag in `render_block` to control whether the CLI command used for rendering is logged, falling back to the logger’s INFO level when unset.

New Features:
- Add `verbose` parameter to `render_block` to enable toggling of CLI command logging

Enhancements:
- Update `render_block` docstring to describe the `verbose` flag behavior
- Implement conditional logging of the rendering command based on the `verbose` flag or the logger's INFO level