### PR TITLE
Refactor mermaid rendering helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,9 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+
+# Crush agentic coding tool
+.crush
+
+# Editor backups
+**/*~

--- a/CRUSH.md
+++ b/CRUSH.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+.PHONY: help all clean test build lint fmt check-fmt markdownlint nixie
+
+RUFF ?= uv run ruff
+TY ?= uv run ty
+PYTEST ?= uv run pytest
+BUILD_JOBS ?=
+MDLINT ?= markdownlint
+NIXIE ?= nixie
+
+all: check-fmt lint test ## Default target runs preflight checks
+
+clean: ## Remove build artifacts
+	rm -rf .venv dist/ *.egg-info
+
+build: ## install deps and build bytecode
+	uv venv
+	uv sync --group dev
+
+test: build ## Run tests
+	$(PYTEST) -v
+
+lint: ## Run lint
+	$(RUFF) check
+
+typecheck: build ## Run type checking
+	$(TY) check
+
+fmt: ## Format code
+	$(RUFF) format
+
+check-fmt: ## Verify formatting
+	$(RUFF) format --check
+
+markdownlint: ## Lint Markdown files
+	find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 -- $(MDLINT)
+
+nixie: ## Validate Mermaid diagrams
+	find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 -- $(NIXIE)
+
+help: ## Show available targets
+	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | \
+	awk 'BEGIN {FS=":"; printf "Available targets:\n"} {printf "  %-20s %s\n", $$1, $$2}'

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -106,6 +106,67 @@ async def wait_for_proc(
     return success, stderr
 
 
+def _write_diagram_file(
+    block: str, tmpdir: Path, path: Path, idx: int
+) -> tuple[Path, Path]:
+    """Write ``block`` to a temporary ``.mmd`` file.
+
+    Parameters
+    ----------
+    block
+        Mermaid source code.
+    tmpdir
+        Directory for intermediate files.
+    path
+        Original Markdown file; used for naming only.
+    idx
+        Index of the diagram within ``path``.
+
+    Returns
+    -------
+    tuple[Path, Path]
+        Paths to the ``.mmd`` input file and expected ``.svg`` output.
+    """
+
+    mmd = tmpdir / f"{path.stem}_{idx}.mmd"
+    mmd.write_text(block)
+    return mmd, mmd.with_suffix(".svg")
+
+
+async def _run_mermaid_cli(
+    mmd: Path,
+    svg: Path,
+    cfg_path: Path,
+    semaphore: asyncio.Semaphore,
+    path: Path,
+    idx: int,
+    timeout: float,
+) -> None:
+    """Invoke ``mermaid-cli`` to render ``mmd`` into ``svg``.
+
+    Raises
+    ------
+    RuntimeError
+        If the CLI exits with a non-zero status.
+    FileNotFoundError
+        If the CLI executable cannot be found.
+    """
+
+    cmd = get_mmdc_cmd(mmd, svg, cfg_path)
+    logging.getLogger(__name__).info(shlex.join(cmd))
+
+    async with semaphore:
+        proc = await asyncio.create_subprocess_exec(  # nosemgrep: python.lang.security.audit.dangerous-asyncio-create-exec-audit
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+    success, stderr = await wait_for_proc(proc, path, idx, timeout)
+    if not success:
+        raise RuntimeError(format_cli_error(stderr.decode("utf-8", errors="replace")))
+
+
 async def render_block(
     block: str,
     tmpdir: Path,
@@ -138,51 +199,25 @@ async def render_block(
         When command logging is enabled, the command line used for rendering is
         logged at ``INFO`` level.
     """
-    mmd = tmpdir / f"{path.stem}_{idx}.mmd"
-    svg = mmd.with_suffix(".svg")
-
     try:
-        mmd.write_text(block)
-
-        cmd = get_mmdc_cmd(mmd, svg, cfg_path)
-        logger = logging.getLogger(__name__)
-        should_log = (
-            verbose if verbose is not None else logger.isEnabledFor(logging.INFO)
+        mmd, svg = _write_diagram_file(block, tmpdir, path, idx)
+        await _run_mermaid_cli(mmd, svg, cfg_path, semaphore, path, idx, timeout)
+        return True
+    except FileNotFoundError as exc:
+        cli = exc.filename or "mmdc"
+        print(
+            (
+                f"Error: '{cli}' not found. Install Node.js with npx "
+                "or Bun to use @mermaid-js/mermaid-cli."
+            ),
+            file=sys.stderr,
         )
-        if should_log:
-            logger.info(shlex.join(cmd))
-        cli = cmd[0]
-
-        async with semaphore:
-            try:
-                proc = await asyncio.create_subprocess_exec(  # nosemgrep: python.lang.security.audit.dangerous-asyncio-create-exec-audit
-                    *cmd,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                )
-            except FileNotFoundError:
-                print(
-                    (
-                        f"Error: '{cli}' not found. Install Node.js with npx "
-                        "or Bun to use @mermaid-js/mermaid-cli."
-                    ),
-                    file=sys.stderr,
-                )
-                return False
-
-            success, stderr = await wait_for_proc(proc, path, idx, timeout)
-            if not success:
-                print(
-                    format_cli_error(stderr.decode("utf-8", errors="replace")),
-                    file=sys.stderr,
-                )
-                return False
-            return True
-
+    except RuntimeError as exc:
+        print(exc, file=sys.stderr)
     except Exception as exc:
         print(f"{path}: unexpected error in diagram {idx}", file=sys.stderr)
         traceback.print_exception(type(exc), exc, exc.__traceback__, file=sys.stderr)
-        return False
+    return False
 
 
 def default_concurrency() -> int:

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -111,6 +111,10 @@ def _write_diagram_file(
 ) -> tuple[Path, Path]:
     """Write ``block`` to a temporary ``.mmd`` file.
 
+    Separating this helper keeps filesystem concerns isolated from the
+    rendering workflow, which aids targeted unit testing and clearer error
+    reporting.
+
     Parameters
     ----------
     block
@@ -141,6 +145,9 @@ async def _run_mermaid_cli(
     timeout: float,
 ) -> None:
     """Invoke ``mermaid-cli`` using ``cmd`` to render a diagram.
+
+    Isolating the CLI invocation simplifies coordination in ``render_block``
+    and allows this behaviour to be exercised in focused tests.
 
     Raises
     ------
@@ -206,7 +213,6 @@ async def render_block(
         mmd, svg = _write_diagram_file(block, tmpdir, path, idx)
         cmd = get_mmdc_cmd(mmd, svg, cfg_path)
         await _run_mermaid_cli(cmd, semaphore, path, idx, timeout)
-        return True
     except FileNotFoundError as exc:
         cli = exc.filename or (cmd[0] if cmd else "mmdc")
         print(
@@ -221,6 +227,8 @@ async def render_block(
     except Exception as exc:
         print(f"{path}: unexpected error in diagram {idx}", file=sys.stderr)
         traceback.print_exception(type(exc), exc, exc.__traceback__, file=sys.stderr)
+    else:
+        return True
     return False
 
 

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -134,15 +134,13 @@ def _write_diagram_file(
 
 
 async def _run_mermaid_cli(
-    mmd: Path,
-    svg: Path,
-    cfg_path: Path,
+    cmd: list[str],
     semaphore: asyncio.Semaphore,
     path: Path,
     idx: int,
     timeout: float,
 ) -> None:
-    """Invoke ``mermaid-cli`` to render ``mmd`` into ``svg``.
+    """Invoke ``mermaid-cli`` using ``cmd`` to render a diagram.
 
     Raises
     ------
@@ -152,7 +150,6 @@ async def _run_mermaid_cli(
         If the CLI executable cannot be found.
     """
 
-    cmd = get_mmdc_cmd(mmd, svg, cfg_path)
     logging.getLogger(__name__).info(shlex.join(cmd))
 
     async with semaphore:
@@ -164,7 +161,12 @@ async def _run_mermaid_cli(
 
     success, stderr = await wait_for_proc(proc, path, idx, timeout)
     if not success:
-        raise RuntimeError(format_cli_error(stderr.decode("utf-8", errors="replace")))
+        error_message = (
+            f"Error running command {shlex.join(cmd)} for file '{path}' "
+            f"(diagram {idx}):\n"
+            f"{format_cli_error(stderr.decode('utf-8', errors='replace'))}"
+        )
+        raise RuntimeError(error_message)
 
 
 async def render_block(
@@ -199,12 +201,14 @@ async def render_block(
         When command logging is enabled, the command line used for rendering is
         logged at ``INFO`` level.
     """
+    cmd: list[str] = []
     try:
         mmd, svg = _write_diagram_file(block, tmpdir, path, idx)
-        await _run_mermaid_cli(mmd, svg, cfg_path, semaphore, path, idx, timeout)
+        cmd = get_mmdc_cmd(mmd, svg, cfg_path)
+        await _run_mermaid_cli(cmd, semaphore, path, idx, timeout)
         return True
     except FileNotFoundError as exc:
-        cli = exc.filename or "mmdc"
+        cli = exc.filename or (cmd[0] if cmd else "mmdc")
         print(
             (
                 f"Error: '{cli}' not found. Install Node.js with npx "

--- a/nixie/unittests/test_run_mermaid_cli.py
+++ b/nixie/unittests/test_run_mermaid_cli.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import shlex
+import shutil
+from pathlib import Path
+
+import pytest
+
+from nixie.cli import _run_mermaid_cli, get_mmdc_cmd
+
+
+@pytest.mark.asyncio
+async def test_run_mermaid_cli_invokes_command(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text("{}")
+    mmd = tmp_path / "diagram.mmd"
+    mmd.write_text("A-->B")
+    svg = mmd.with_suffix(".svg")
+    semaphore = asyncio.Semaphore(1)
+    path = Path("doc.md")
+
+    async def fake_create_subprocess_exec(*cmd: str, **kwargs: object) -> object:
+        return object()
+
+    async def fake_wait_for_proc(
+        proc: object, path: Path, idx: int, timeout: float
+    ) -> tuple[bool, bytes]:
+        return True, b""
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr("nixie.cli.wait_for_proc", fake_wait_for_proc)
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/mmdc")
+
+    with caplog.at_level(logging.INFO, logger="nixie.cli"):
+        await _run_mermaid_cli(mmd, svg, cfg_path, semaphore, path, 1, 30.0)
+
+    expected = shlex.join(get_mmdc_cmd(mmd, svg, cfg_path))
+    assert expected in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_run_mermaid_cli_raises_on_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text("{}")
+    mmd = tmp_path / "diagram.mmd"
+    mmd.write_text("A-->B")
+    svg = mmd.with_suffix(".svg")
+    semaphore = asyncio.Semaphore(1)
+    path = Path("doc.md")
+
+    async def fake_create_subprocess_exec(*cmd: str, **kwargs: object) -> object:
+        return object()
+
+    async def fake_wait_for_proc(
+        proc: object, path: Path, idx: int, timeout: float
+    ) -> tuple[bool, bytes]:
+        return False, b"Parse error on line 1:\nfoo\n^\n"
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr("nixie.cli.wait_for_proc", fake_wait_for_proc)
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/mmdc")
+
+    with pytest.raises(RuntimeError) as err:
+        await _run_mermaid_cli(mmd, svg, cfg_path, semaphore, path, 1, 30.0)
+
+    assert "Parse error on line 1" in str(err.value)

--- a/nixie/unittests/test_run_mermaid_cli.py
+++ b/nixie/unittests/test_run_mermaid_cli.py
@@ -24,6 +24,7 @@ async def test_run_mermaid_cli_invokes_command(
     svg = mmd.with_suffix(".svg")
     semaphore = asyncio.Semaphore(1)
     path = Path("doc.md")
+    cmd = get_mmdc_cmd(mmd, svg, cfg_path)
 
     async def fake_create_subprocess_exec(*cmd: str, **kwargs: object) -> object:
         return object()
@@ -38,9 +39,9 @@ async def test_run_mermaid_cli_invokes_command(
     monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/mmdc")
 
     with caplog.at_level(logging.INFO, logger="nixie.cli"):
-        await _run_mermaid_cli(mmd, svg, cfg_path, semaphore, path, 1, 30.0)
+        await _run_mermaid_cli(cmd, semaphore, path, 1, 30.0)
 
-    expected = shlex.join(get_mmdc_cmd(mmd, svg, cfg_path))
+    expected = shlex.join(cmd)
     assert expected in caplog.text
 
 
@@ -55,6 +56,7 @@ async def test_run_mermaid_cli_raises_on_failure(
     svg = mmd.with_suffix(".svg")
     semaphore = asyncio.Semaphore(1)
     path = Path("doc.md")
+    cmd = get_mmdc_cmd(mmd, svg, cfg_path)
 
     async def fake_create_subprocess_exec(*cmd: str, **kwargs: object) -> object:
         return object()
@@ -69,6 +71,9 @@ async def test_run_mermaid_cli_raises_on_failure(
     monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/mmdc")
 
     with pytest.raises(RuntimeError) as err:
-        await _run_mermaid_cli(mmd, svg, cfg_path, semaphore, path, 1, 30.0)
+        await _run_mermaid_cli(cmd, semaphore, path, 1, 30.0)
 
-    assert "Parse error on line 1" in str(err.value)
+    msg = str(err.value)
+    assert "Parse error on line 1" in msg
+    assert "doc.md" in msg
+    assert "mmdc" in msg

--- a/nixie/unittests/test_write_diagram_file.py
+++ b/nixie/unittests/test_write_diagram_file.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from nixie.cli import _write_diagram_file
+
+
+def test_write_diagram_file(tmp_path: Path) -> None:
+    path = Path("doc.md")
+    block = "A-->B"
+
+    mmd, svg = _write_diagram_file(block, tmp_path, path, 1)
+
+    assert mmd.read_text() == block
+    assert svg == mmd.with_suffix(".svg")
+    assert mmd.exists()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
   "Operating System :: OS Independent",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
   "ruff",
   "pyright",

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,155 @@
+version = 1
+revision = 2
+requires-python = ">=3.11"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "nixie"
+version = "0.1.0"
+source = { editable = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437, upload-time = "2024-06-04T18:44:11.171Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314, upload-time = "2024-06-04T18:44:08.352Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.403"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/f6/35f885264ff08c960b23d1542038d8da86971c5d8c955cfab195a4f672d7/pyright-1.1.403.tar.gz", hash = "sha256:3ab69b9f41c67fb5bbb4d7a36243256f0d549ed3608678d381d5f51863921104", size = 3913526, upload-time = "2025-07-09T07:15:52.882Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/b6/b04e5c2f41a5ccad74a1a4759da41adb20b4bc9d59a5e08d29ba60084d07/pyright-1.1.403-py3-none-any.whl", hash = "sha256:c0eeca5aa76cbef3fcc271259bbd785753c7ad7bcac99a9162b4c4c7daed23b3", size = 5684504, upload-time = "2025-07-09T07:15:50.958Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/51/f8794af39eeb870e87a8c8068642fc07bce0c854d6865d7dd0f2a9d338c2/pytest_asyncio-1.1.0.tar.gz", hash = "sha256:796aa822981e01b68c12e4827b8697108f7205020f24b5793b3c41555dab68ea", size = 46652, upload-time = "2025-07-16T04:29:26.393Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/9d/bf86eddabf8c6c9cb1ea9a869d6873b46f105a5d292d3a6f7071f5b07935/pytest_asyncio-1.1.0-py3-none-any.whl", hash = "sha256:5fe2d69607b0bd75c656d1211f969cadba035030156745ee09e7d71740e58ecf", size = 15157, upload-time = "2025-07-16T04:29:24.929Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.12.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/81/0bd3594fa0f690466e41bd033bdcdf86cba8288345ac77ad4afbe5ec743a/ruff-0.12.7.tar.gz", hash = "sha256:1fc3193f238bc2d7968772c82831a4ff69252f673be371fb49663f0068b7ec71", size = 5197814, upload-time = "2025-07-29T22:32:35.877Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/d2/6cb35e9c85e7a91e8d22ab32ae07ac39cc34a71f1009a6f9e4a2a019e602/ruff-0.12.7-py3-none-linux_armv6l.whl", hash = "sha256:76e4f31529899b8c434c3c1dede98c4483b89590e15fb49f2d46183801565303", size = 11852189, upload-time = "2025-07-29T22:31:41.281Z" },
+    { url = "https://files.pythonhosted.org/packages/63/5b/a4136b9921aa84638f1a6be7fb086f8cad0fde538ba76bda3682f2599a2f/ruff-0.12.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:789b7a03e72507c54fb3ba6209e4bb36517b90f1a3569ea17084e3fd295500fb", size = 12519389, upload-time = "2025-07-29T22:31:54.265Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/c9/3e24a8472484269b6b1821794141f879c54645a111ded4b6f58f9ab0705f/ruff-0.12.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2e1c2a3b8626339bb6369116e7030a4cf194ea48f49b64bb505732a7fce4f4e3", size = 11743384, upload-time = "2025-07-29T22:31:59.575Z" },
+    { url = "https://files.pythonhosted.org/packages/26/7c/458dd25deeb3452c43eaee853c0b17a1e84169f8021a26d500ead77964fd/ruff-0.12.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32dec41817623d388e645612ec70d5757a6d9c035f3744a52c7b195a57e03860", size = 11943759, upload-time = "2025-07-29T22:32:01.95Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/8b/658798472ef260ca050e400ab96ef7e85c366c39cf3dfbef4d0a46a528b6/ruff-0.12.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47ef751f722053a5df5fa48d412dbb54d41ab9b17875c6840a58ec63ff0c247c", size = 11654028, upload-time = "2025-07-29T22:32:04.367Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/86/9c2336f13b2a3326d06d39178fd3448dcc7025f82514d1b15816fe42bfe8/ruff-0.12.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a828a5fc25a3efd3e1ff7b241fd392686c9386f20e5ac90aa9234a5faa12c423", size = 13225209, upload-time = "2025-07-29T22:32:06.952Z" },
+    { url = "https://files.pythonhosted.org/packages/76/69/df73f65f53d6c463b19b6b312fd2391dc36425d926ec237a7ed028a90fc1/ruff-0.12.7-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:5726f59b171111fa6a69d82aef48f00b56598b03a22f0f4170664ff4d8298efb", size = 14182353, upload-time = "2025-07-29T22:32:10.053Z" },
+    { url = "https://files.pythonhosted.org/packages/58/1e/de6cda406d99fea84b66811c189b5ea139814b98125b052424b55d28a41c/ruff-0.12.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:74e6f5c04c4dd4aba223f4fe6e7104f79e0eebf7d307e4f9b18c18362124bccd", size = 13631555, upload-time = "2025-07-29T22:32:12.644Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ae/625d46d5164a6cc9261945a5e89df24457dc8262539ace3ac36c40f0b51e/ruff-0.12.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5d0bfe4e77fba61bf2ccadf8cf005d6133e3ce08793bbe870dd1c734f2699a3e", size = 12667556, upload-time = "2025-07-29T22:32:15.312Z" },
+    { url = "https://files.pythonhosted.org/packages/55/bf/9cb1ea5e3066779e42ade8d0cd3d3b0582a5720a814ae1586f85014656b6/ruff-0.12.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06bfb01e1623bf7f59ea749a841da56f8f653d641bfd046edee32ede7ff6c606", size = 12939784, upload-time = "2025-07-29T22:32:17.69Z" },
+    { url = "https://files.pythonhosted.org/packages/55/7f/7ead2663be5627c04be83754c4f3096603bf5e99ed856c7cd29618c691bd/ruff-0.12.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e41df94a957d50083fd09b916d6e89e497246698c3f3d5c681c8b3e7b9bb4ac8", size = 11771356, upload-time = "2025-07-29T22:32:20.134Z" },
+    { url = "https://files.pythonhosted.org/packages/17/40/a95352ea16edf78cd3a938085dccc55df692a4d8ba1b3af7accbe2c806b0/ruff-0.12.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:4000623300563c709458d0ce170c3d0d788c23a058912f28bbadc6f905d67afa", size = 11612124, upload-time = "2025-07-29T22:32:22.645Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/74/633b04871c669e23b8917877e812376827c06df866e1677f15abfadc95cb/ruff-0.12.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:69ffe0e5f9b2cf2b8e289a3f8945b402a1b19eff24ec389f45f23c42a3dd6fb5", size = 12479945, upload-time = "2025-07-29T22:32:24.765Z" },
+    { url = "https://files.pythonhosted.org/packages/be/34/c3ef2d7799c9778b835a76189c6f53c179d3bdebc8c65288c29032e03613/ruff-0.12.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a07a5c8ffa2611a52732bdc67bf88e243abd84fe2d7f6daef3826b59abbfeda4", size = 12998677, upload-time = "2025-07-29T22:32:27.022Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ab/aca2e756ad7b09b3d662a41773f3edcbd262872a4fc81f920dc1ffa44541/ruff-0.12.7-py3-none-win32.whl", hash = "sha256:c928f1b2ec59fb77dfdf70e0419408898b63998789cc98197e15f560b9e77f77", size = 11756687, upload-time = "2025-07-29T22:32:29.381Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/71/26d45a5042bc71db22ddd8252ca9d01e9ca454f230e2996bb04f16d72799/ruff-0.12.7-py3-none-win_amd64.whl", hash = "sha256:9c18f3d707ee9edf89da76131956aba1270c6348bfee8f6c647de841eac7194f", size = 12912365, upload-time = "2025-07-29T22:32:31.517Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/9b/0b8aa09817b63e78d94b4977f18b1fcaead3165a5ee49251c5d5c245bb2d/ruff-0.12.7-py3-none-win_arm64.whl", hash = "sha256:dfce05101dbd11833a0776716d5d1578641b7fddb537fe7fa956ab85d1769b69", size = 11982083, upload-time = "2025-07-29T22:32:33.881Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.14.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36", size = 107673, upload-time = "2025-07-04T13:28:34.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76", size = 43906, upload-time = "2025-07-04T13:28:32.743Z" },
+]


### PR DESCRIPTION
## Summary
- extract `_write_diagram_file` and `_run_mermaid_cli` helpers
- simplify `render_block` to coordinate helpers
- add unit tests for new helpers

## Testing
- `ruff check nixie/cli.py nixie/unittests/test_write_diagram_file.py nixie/unittests/test_run_mermaid_cli.py`
- `pyright nixie/cli.py nixie/unittests/test_write_diagram_file.py nixie/unittests/test_run_mermaid_cli.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893db328e788322a7e0aeb1bd1bf745

## Summary by Sourcery

Refactor mermaid diagram rendering by extracting helper functions and adding unit tests for them

Enhancements:
- Extract _write_diagram_file helper to isolate file writing logic
- Extract _run_mermaid_cli helper to encapsulate CLI invocation
- Simplify render_block to coordinate the new helpers

Tests:
- Add unit tests for _write_diagram_file
- Add unit tests for _run_mermaid_cli