### PR TITLE
Remove unused verbose parameter

### DIFF
--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -182,6 +182,9 @@ async def _render_diagram(
     mmd.write_text(block)
 
     cmd = get_mmdc_cmd(mmd, svg, cfg_path)
+    allowed_executables = {"mmdc", "bun", "npx"}
+    if not cmd or cmd[0] not in allowed_executables:
+        raise ValueError(f"Unexpected executable: {cmd[0] if cmd else ''}")
     logging.getLogger(__name__).info(shlex.join(cmd))
 
     success, stderr = await _run_mermaid_cli(cmd, sem, path, idx, timeout)

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -35,6 +35,8 @@ BLOCK_RE = re.compile(
     re.DOTALL | re.MULTILINE,
 )
 
+ALLOWED_EXECUTABLES: typing.Final[frozenset[str]] = frozenset({"mmdc", "bun", "npx"})
+
 
 def parse_blocks(text: str) -> list[str]:
     """Return all mermaid code blocks found in the text."""
@@ -124,8 +126,7 @@ async def _run_mermaid_cli(
     idx: int,
     timeout: float,
 ) -> tuple[bool, bytes]:
-    allowed_executables = {"mmdc", "bun", "npx"}
-    if not cmd or cmd[0] not in allowed_executables:
+    if not cmd or cmd[0] not in ALLOWED_EXECUTABLES:
         raise ValueError(f"Unexpected executable: {cmd[0] if cmd else ''}")
 
     async with sem:
@@ -182,8 +183,7 @@ async def _render_diagram(
     mmd.write_text(block)
 
     cmd = get_mmdc_cmd(mmd, svg, cfg_path)
-    allowed_executables = {"mmdc", "bun", "npx"}
-    if not cmd or cmd[0] not in allowed_executables:
+    if not cmd or cmd[0] not in ALLOWED_EXECUTABLES:
         raise ValueError(f"Unexpected executable: {cmd[0] if cmd else ''}")
     logging.getLogger(__name__).info(shlex.join(cmd))
 

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -163,6 +163,10 @@ async def _render_diagram(
     cmd = get_mmdc_cmd(mmd, svg, cfg_path)
     logging.getLogger(__name__).info(shlex.join(cmd))
 
+    allowed_executables = {"mmdc", "bun", "npx"}
+    if cmd[0] not in allowed_executables:
+        raise ValueError(f"Unexpected executable: {cmd[0]}")
+
     async with sem:
         proc = await asyncio.create_subprocess_exec(  # nosemgrep: python.lang.security.audit.dangerous-asyncio-create-exec-audit
             *cmd,

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -117,6 +117,27 @@ async def wait_for_proc(
     return success, stderr
 
 
+async def _run_mermaid_cli(
+    cmd: list[str],
+    sem: asyncio.Semaphore,
+    path: Path,
+    idx: int,
+    timeout: float,
+) -> tuple[bool, bytes]:
+    allowed_executables = {"mmdc", "bun", "npx"}
+    if not cmd or cmd[0] not in allowed_executables:
+        raise ValueError(f"Unexpected executable: {cmd[0] if cmd else ''}")
+
+    async with sem:
+        proc = await asyncio.create_subprocess_exec(  # nosemgrep: python.lang.security.audit.dangerous-asyncio-create-exec-audit
+            *cmd,
+            stdout=asyncio_subprocess.PIPE,
+            stderr=asyncio_subprocess.PIPE,
+        )
+
+    return await wait_for_proc(proc, path, idx, timeout)
+
+
 async def _render_diagram(
     block: str,
     tmpdir: Path,
@@ -163,18 +184,7 @@ async def _render_diagram(
     cmd = get_mmdc_cmd(mmd, svg, cfg_path)
     logging.getLogger(__name__).info(shlex.join(cmd))
 
-    allowed_executables = {"mmdc", "bun", "npx"}
-    if cmd[0] not in allowed_executables:
-        raise ValueError(f"Unexpected executable: {cmd[0]}")
-
-    async with sem:
-        proc = await asyncio.create_subprocess_exec(  # nosemgrep: python.lang.security.audit.dangerous-asyncio-create-exec-audit
-            *cmd,
-            stdout=asyncio_subprocess.PIPE,
-            stderr=asyncio_subprocess.PIPE,
-        )
-
-    success, stderr = await wait_for_proc(proc, path, idx, timeout)
+    success, stderr = await _run_mermaid_cli(cmd, sem, path, idx, timeout)
     if not success:
         error_message = (
             f"Error running command {shlex.join(cmd)} for file '{path}' "

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import asyncio.subprocess
+import asyncio.subprocess as asyncio_subprocess
 import json
 import logging
 import os
@@ -103,7 +103,7 @@ def format_cli_error(stderr: str) -> str:
 
 
 async def wait_for_proc(
-    proc: asyncio.subprocess.Process, path: Path, idx: int, timeout: float = 30.0
+    proc: asyncio_subprocess.Process, path: Path, idx: int, timeout: float = 30.0
 ) -> tuple[bool, bytes]:
     """Wait for a process to complete and return its success status and stderr."""
     try:
@@ -166,8 +166,8 @@ async def _render_diagram(
     async with sem:
         proc = await asyncio.create_subprocess_exec(  # nosemgrep: python.lang.security.audit.dangerous-asyncio-create-exec-audit
             *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+            stdout=asyncio_subprocess.PIPE,
+            stderr=asyncio_subprocess.PIPE,
         )
 
     success, stderr = await wait_for_proc(proc, path, idx, timeout)

--- a/nixie/unittests/test_render_diagram.py
+++ b/nixie/unittests/test_render_diagram.py
@@ -72,3 +72,12 @@ async def test_render_diagram_raises_on_failure(
     assert "Parse error on line 1" in msg
     assert "doc.md" in msg
     assert "mmdc" in msg
+
+
+@pytest.mark.asyncio
+async def test_run_mermaid_cli_rejects_unexpected_executable() -> None:
+    semaphore = asyncio.Semaphore(1)
+    path = Path("doc.md")
+    cmd = ["echo", "hello"]
+    with pytest.raises(ValueError, match="Unexpected executable"):
+        await _run_mermaid_cli(cmd, semaphore, path, 1, 30.0)

--- a/nixie/unittests/test_render_diagram.py
+++ b/nixie/unittests/test_render_diagram.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from nixie.cli import _render_diagram, get_mmdc_cmd
+from nixie.cli import _render_diagram, get_mmdc_cmd, _run_mermaid_cli
 
 
 @pytest.mark.asyncio

--- a/nixie/unittests/test_verbose.py
+++ b/nixie/unittests/test_verbose.py
@@ -53,7 +53,7 @@ async def test_render_block_emits_command(
 
 
 @pytest.mark.asyncio
-async def test_render_block_silent_without_verbose(
+async def test_render_block_silent_when_warning_level(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
## Summary
- drop unused `verbose` arg from `render_block`
- fix type annotations by importing `asyncio.subprocess`
- rename test to reflect logging behavior

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6894ef14e6a083229493ae05c0a8684e

## Summary by Sourcery

Clean up render_block by dropping the unused verbose argument, updating subprocess type imports, and renaming the test to match logging behavior

Enhancements:
- Remove the unused verbose parameter from render_block
- Fix type annotations by aliasing asyncio.subprocess imports
- Simplify render_block docstring to reflect INFO-level logging

Tests:
- Rename test_render_block to reflect warning-level logging behavior