### PR TITLE
Merge file and CLI rendering helpers

### DIFF
--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -219,7 +219,7 @@ async def render_block(
         )
     except RuntimeError as exc:
         print(exc, file=sys.stderr)
-    except Exception as exc:
+    except Exception as exc:  # pragma: no cover - unexpected
         print(f"{path}: unexpected error in diagram {idx}", file=sys.stderr)
         traceback.print_exception(type(exc), exc, exc.__traceback__, file=sys.stderr)
     else:

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -108,7 +108,7 @@ async def wait_for_proc(
     """Wait for a process to complete and return its success status and stderr."""
     try:
         _, stderr = await asyncio.wait_for(proc.communicate(), timeout)
-    except asyncio.TimeoutError:
+    except TimeoutError:
         proc.kill()
         await proc.wait()
         print(f"{path}: diagram {idx} timed out", file=sys.stderr)
@@ -212,9 +212,7 @@ async def render_block(
     except FileNotFoundError as exc:
         cli = exc.filename or "mmdc"
         print(
-            "Error: '{0}' not found. Install Node.js with npx or Bun to use @mermaid-js/mermaid-cli.".format(
-                cli
-            ),
+            f"Error: '{cli}' not found. Install Node.js with npx or Bun to use @mermaid-js/mermaid-cli.",
             file=sys.stderr,
         )
     except RuntimeError as exc:

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -22,7 +22,6 @@ import shlex
 import shutil
 import sys
 import tempfile
-import traceback
 import typing
 from contextlib import contextmanager
 from pathlib import Path
@@ -217,9 +216,6 @@ async def render_block(
         )
     except RuntimeError as exc:
         print(exc, file=sys.stderr)
-    except Exception as exc:  # pragma: no cover - unexpected
-        print(f"{path}: unexpected error in diagram {idx}", file=sys.stderr)
-        traceback.print_exception(type(exc), exc, exc.__traceback__, file=sys.stderr)
     else:
         return True
     return False

--- a/nixie/unittests/test_render_diagram.py
+++ b/nixie/unittests/test_render_diagram.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-
 import asyncio
 import logging
 import shlex


### PR DESCRIPTION
## Summary
- merge temporary file writing and mermaid CLI invocation into unified `_render_diagram`
- simplify `render_block` to delegate rendering logic and report failures
- replace unit tests to cover `_render_diagram` success and error paths

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6894edfc5bdc8322ba7765033e341b37

## Summary by Sourcery

Unify file writing and Mermaid CLI invocation into a single helper, simplify render_block to delegate rendering and handle errors, and update unit tests to cover the new rendering workflow.

Enhancements:
- Unify diagram file creation and Mermaid CLI invocation into a single _render_diagram helper
- Simplify render_block to delegate rendering logic and handle errors without a verbose flag
- Streamline CLI error reporting to display only formatted stderr messages
- Remove redundant _write_diagram_file and _run_mermaid_cli functions

Tests:
- Replace tests for file-writing and CLI helpers with new tests targeting _render_diagram for both success and failure scenarios