### PR TITLE
Extend rendering semaphore and restore verbose shim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,11 @@ clean: ## Remove build artifacts
 	rm -rf .venv dist/ *.egg-info
 
 build: ## install deps and build bytecode
-	uv venv
-	uv sync --group dev
+	@if [ -x .venv/bin/python ]; then \
+		echo "venv present; skipping uv setup"; \
+	else \
+		uv venv && uv sync --group dev; \
+	fi
 
 test: build ## Run tests
 	$(PYTEST) -v

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ nixie [--concurrency N] [--verbose] FILE [FILE...]
 to the number of CPU cores or `4` if this cannot be determined). Paths can be
 files or directories.
 
-`--verbose` logs the exact `mermaid-cli` command for each diagram.
+`--verbose` is **deprecated** and will be removed in v0.2.0. Set the
+`nixie.cli` logger to `INFO` to log the exact `mermaid-cli` command for each
+diagram.
 
 When multiple files are provided, nixie prints markers that show where the
 output for each file starts and ends:

--- a/README.md
+++ b/README.md
@@ -47,9 +47,8 @@ nixie [--concurrency N] [--verbose] FILE [FILE...]
 to the number of CPU cores or `4` if this cannot be determined). Paths can be
 files or directories.
 
-`--verbose` is **deprecated** and will be removed in v0.2.0. Set the
-`nixie.cli` logger to `INFO` to log the exact `mermaid-cli` command for each
-diagram.
+`--verbose` sets the `nixie.cli` logger to `INFO`, logging the exact
+`mermaid-cli` command for each diagram.
 
 When multiple files are provided, nixie prints markers that show where the
 output for each file starts and ends:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+- Deprecate `render_block(verbose=...)` and `--verbose` CLI option. These will
+  be removed in v0.2.0; set the `nixie.cli` logger to INFO to log
+  `mermaid-cli` commands.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,5 +3,6 @@
 ## Unreleased
 
 - `--verbose` now sets the `nixie.cli` logger to INFO, logging the underlying
-  `mermaid-cli` commands. The `render_block(verbose=...)` parameter mirrors this
-  behaviour.
+   `mermaid-cli` commands. The `render_block(verbose=...)` parameter is
+   deprecated and has no effect; configure the `nixie.cli` logger directly
+   instead.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 ## Unreleased
 
-- Deprecate `render_block(verbose=...)` and `--verbose` CLI option. These will
-  be removed in v0.2.0; set the `nixie.cli` logger to INFO to log
-  `mermaid-cli` commands.
+- `--verbose` now sets the `nixie.cli` logger to INFO, logging the underlying
+  `mermaid-cli` commands. The `render_block(verbose=...)` parameter mirrors this
+  behaviour.

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -25,7 +25,6 @@ import shlex
 import shutil
 import sys
 import tempfile
-import typing
 import typing as typ
 import warnings
 from contextlib import contextmanager, suppress
@@ -84,7 +83,7 @@ def create_puppeteer_config() -> typ.Generator[Path]:
         yield path
     finally:
         with suppress(OSError):
-            path.unlink()
+            path.unlink(missing_ok=True)
 
 
 def get_mmdc_cmd(mmd: Path, svg: Path, cfg_path: Path) -> list[str]:
@@ -201,7 +200,8 @@ async def _render_diagram(
     logging.getLogger(__name__).info(shlex.join(cmd))
 
     async with semaphore:
-        proc = await asyncio.create_subprocess_exec(  # nosemgrep: python.lang.security.audit.dangerous-asyncio-create-exec-audit
+        # nosemgrep: python.lang.security.audit.dangerous-asyncio-create-exec-audit
+        proc = await asyncio.create_subprocess_exec(
             *cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
@@ -268,8 +268,11 @@ async def render_block(
         await _render_diagram(block, tmpdir, cfg_path, path, idx, semaphore, timeout)
     except FileNotFoundError as exc:
         cli = exc.filename or "mmdc"
-        logging.getLogger(__name__).error(
-            "Error: '%s' not found. Install Node.js with npx or Bun to use @mermaid-js/mermaid-cli.",
+        logging.getLogger(__name__).exception(
+            (
+                "Error: '%s' not found. Install Node.js with npx or Bun to use "
+                "@mermaid-js/mermaid-cli."
+            ),
             cli,
         )
     except RuntimeError:

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -366,9 +366,13 @@ def parse_args() -> argparse.Namespace:
 def cli() -> None:
     """Entry point for the ``nixie`` console script."""
     parsed = parse_args()
-    logging.basicConfig(level=logging.WARNING, stream=sys.stderr)
-    if parsed.verbose:
-        logging.getLogger(__name__).setLevel(logging.INFO)
+    logger = logging.getLogger(__name__)
+    if not logger.handlers:
+        handler = logging.StreamHandler(stream=sys.stderr)
+        handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+        logger.addHandler(handler)
+        logger.propagate = False
+    logger.setLevel(logging.INFO if parsed.verbose else logging.WARNING)
     sys.exit(asyncio.run(main(parsed.paths, parsed.concurrency)))
 
 

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -7,6 +7,10 @@ them with the `mermaid-cli` tool. It supports concurrent rendering via
 
 Usage:
     nixie [--concurrency N] [--verbose] path1.md [path2.md ...]
+
+The ``--verbose`` flag is deprecated and will be removed in v0.2.0. To emit
+the underlying ``mermaid-cli`` commands, set the ``nixie.cli`` logger to
+``INFO``.
 """
 
 from __future__ import annotations
@@ -229,6 +233,8 @@ async def render_block(
         semaphore: Limits concurrent CLI invocations.
         timeout: Maximum time in seconds to wait for the CLI to finish.
         verbose: Deprecated. Configure logging to control command emission.
+            This option will be removed in v0.2.0; set the "nixie.cli" logger
+            level to ``INFO`` to replicate its behaviour.
 
     Returns
     -------
@@ -240,7 +246,10 @@ async def render_block(
     """
     if verbose is not None:
         warnings.warn(
-            "render_block(verbose=...) is deprecated; configure logging level instead",
+            (
+                "render_block(verbose=...) is deprecated and will be removed in v0.2.0; "
+                'set the "nixie.cli" logger to INFO to emit command lines'
+            ),
             DeprecationWarning,
             stacklevel=2,
         )
@@ -255,7 +264,11 @@ async def render_block(
             file=sys.stderr,
         )
     except RuntimeError as exc:
-        print(exc, file=sys.stderr)
+        logging.getLogger(__name__).error("%s", exc)
+    except Exception:
+        logging.getLogger(__name__).exception(
+            "%s: unexpected error in diagram %s", path, idx
+        )
     else:
         return True
     return False
@@ -340,7 +353,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--verbose",
         action="store_true",
-        help="Log the command line of each mermaid-cli invocation",
+        help=(
+            "[DEPRECATED] Log mermaid-cli commands; set the 'nixie.cli' logger "
+            "to INFO instead"
+        ),
     )
     return parser.parse_args()
 
@@ -357,4 +373,3 @@ def cli() -> None:
 
 if __name__ == "__main__":
     cli()
-

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -8,9 +8,8 @@ them with the `mermaid-cli` tool. It supports concurrent rendering via
 Usage:
     nixie [--concurrency N] [--verbose] path1.md [path2.md ...]
 
-The ``--verbose`` flag is deprecated and will be removed in v0.2.0. To emit
-the underlying ``mermaid-cli`` commands, set the ``nixie.cli`` logger to
-``INFO``.
+The ``--verbose`` flag sets the ``nixie.cli`` logger to ``INFO`` to emit the
+underlying ``mermaid-cli`` commands.
 """
 
 from __future__ import annotations
@@ -28,7 +27,6 @@ import sys
 import tempfile
 import typing
 import typing as typ
-import warnings
 from contextlib import contextmanager, suppress
 from pathlib import Path
 
@@ -232,9 +230,8 @@ async def render_block(
         idx: Index of the block within ``path``.
         semaphore: Limits concurrent CLI invocations.
         timeout: Maximum time in seconds to wait for the CLI to finish.
-        verbose: Deprecated. Configure logging to control command emission.
-            This option will be removed in v0.2.0; set the "nixie.cli" logger
-            level to ``INFO`` to replicate its behaviour.
+        verbose: If ``True``, set the ``nixie.cli`` logger to ``INFO`` to
+            emit command lines. Preserved for backward compatibility.
 
     Returns
     -------
@@ -244,15 +241,8 @@ async def render_block(
     -----
         The command line used for rendering is logged at ``INFO`` level.
     """
-    if verbose is not None:
-        warnings.warn(
-            (
-                "render_block(verbose=...) is deprecated and will be removed in v0.2.0; "
-                'set the "nixie.cli" logger to INFO to emit command lines'
-            ),
-            DeprecationWarning,
-            stacklevel=2,
-        )
+    if verbose:
+        logging.getLogger(__name__).setLevel(logging.INFO)
     try:
         await _render_diagram(block, tmpdir, cfg_path, path, idx, semaphore, timeout)
     except FileNotFoundError as exc:
@@ -353,10 +343,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--verbose",
         action="store_true",
-        help=(
-            "[DEPRECATED] Log mermaid-cli commands; set the 'nixie.cli' logger "
-            "to INFO instead"
-        ),
+        help="Log mermaid-cli commands for each diagram",
     )
     return parser.parse_args()
 
@@ -364,10 +351,9 @@ def parse_args() -> argparse.Namespace:
 def cli() -> None:
     """Entry point for the ``nixie`` console script."""
     parsed = parse_args()
-    logging.basicConfig(
-        level=logging.INFO if parsed.verbose else logging.WARNING,
-        stream=sys.stderr,
-    )
+    logging.basicConfig(level=logging.WARNING, stream=sys.stderr)
+    if parsed.verbose:
+        logging.getLogger(__name__).setLevel(logging.INFO)
     sys.exit(asyncio.run(main(parsed.paths, parsed.concurrency)))
 
 

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -33,6 +33,8 @@ from pathlib import Path
 if typ.TYPE_CHECKING:
     import collections.abc as cabc
 
+LOGGER = logging.getLogger(__name__)
+
 BLOCK_RE = re.compile(
     r"^```\s*mermaid\s*\n(.*?)\n```[ \t]*$",
     re.DOTALL | re.MULTILINE,
@@ -197,7 +199,7 @@ async def _render_diagram(
     cmd = get_mmdc_cmd(mmd, svg, cfg_path)
     if not cmd or cmd[0] not in ALLOWED_EXECUTABLES:
         raise UnexpectedExecutableError(cmd[0] if cmd else "")
-    logging.getLogger(__name__).info(shlex.join(cmd))
+    LOGGER.info(shlex.join(cmd))
 
     async with semaphore:
         # nosemgrep: python.lang.security.audit.dangerous-asyncio-create-exec-audit
@@ -268,7 +270,7 @@ async def render_block(
         await _render_diagram(block, tmpdir, cfg_path, path, idx, semaphore, timeout)
     except FileNotFoundError as exc:
         cli = exc.filename or "mmdc"
-        logging.getLogger(__name__).exception(
+        LOGGER.exception(
             (
                 "Error: '%s' not found. Install Node.js with npx or Bun to use "
                 "@mermaid-js/mermaid-cli."
@@ -276,11 +278,11 @@ async def render_block(
             cli,
         )
     except RuntimeError:
-        logging.getLogger(__name__).exception("Runtime error while rendering diagram")
+        LOGGER.exception("Runtime error while rendering diagram")
     except Exception as exc:
         if isinstance(exc, KeyboardInterrupt | SystemExit):
             raise
-        logging.getLogger(__name__).exception(
+        LOGGER.exception(
             "%s: unexpected error in diagram %s",
             path,
             idx,
@@ -377,7 +379,7 @@ def parse_args() -> argparse.Namespace:
 def cli() -> None:
     """Entry point for the ``nixie`` console script."""
     parsed = parse_args()
-    logger = logging.getLogger(__name__)
+    logger = LOGGER
     if not logger.handlers:
         handler = logging.StreamHandler(stream=sys.stderr)
         handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -158,7 +158,7 @@ async def _render_diagram(
     cfg_path: Path,
     path: Path,
     idx: int,
-    sem: asyncio.Semaphore,
+    semaphore: asyncio.Semaphore,
     timeout: float,
 ) -> None:
     """Write ``block`` to disk and invoke ``mermaid-cli``.
@@ -178,7 +178,7 @@ async def _render_diagram(
         Markdown file containing the diagram; used for naming only.
     idx
         Index of the diagram within ``path``.
-    sem
+    semaphore
         Semaphore limiting concurrent CLI executions.
     timeout
         Maximum time in seconds to wait for the CLI to finish.
@@ -199,7 +199,13 @@ async def _render_diagram(
         raise UnexpectedExecutableError(cmd[0] if cmd else "")
     logging.getLogger(__name__).info(shlex.join(cmd))
 
-    success, stderr = await _run_mermaid_cli(cmd, sem, path, idx, timeout)
+    async with semaphore:
+        proc = await asyncio.create_subprocess_exec(  # nosemgrep: python.lang.security.audit.dangerous-asyncio-create-exec-audit
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        success, stderr = await wait_for_proc(proc, path, idx, timeout)
     if not success:
         error_message = (
             f"Error running command {shlex.join(cmd)} for file '{path}' "
@@ -247,17 +253,29 @@ async def render_block(
         await _render_diagram(block, tmpdir, cfg_path, path, idx, semaphore, timeout)
     except FileNotFoundError as exc:
         cli = exc.filename or "mmdc"
+<<<<<<< HEAD
         print(
             "Error: "
             f"'{cli}' not found. Install Node.js with npx or Bun to use "
             "@mermaid-js/mermaid-cli.",
             file=sys.stderr,
+||||||| parent of c8480b7 (Log rendering errors with tracebacks)
+        logging.getLogger(__name__).error(
+            "Error: '%s' not found. Install Node.js with npx or Bun to use @mermaid-js/mermaid-cli.",
+            cli,
+=======
+        logging.getLogger(__name__).exception(
+            "Error: '%s' not found. Install Node.js with npx or Bun to use @mermaid-js/mermaid-cli.",
+            cli,
+>>>>>>> c8480b7 (Log rendering errors with tracebacks)
         )
-    except RuntimeError as exc:
-        logging.getLogger(__name__).error("%s", exc)
+    except RuntimeError:
+        logging.getLogger(__name__).exception("Runtime error while rendering diagram")
     except Exception:
         logging.getLogger(__name__).exception(
-            "%s: unexpected error in diagram %s", path, idx
+            "%s: unexpected error in diagram %s",
+            path,
+            idx,
         )
     else:
         return True

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -22,7 +22,9 @@ import shlex
 import shutil
 import sys
 import tempfile
+import typing
 import typing as typ
+import warnings
 from contextlib import contextmanager, suppress
 from pathlib import Path
 
@@ -214,6 +216,7 @@ async def render_block(
     semaphore: asyncio.Semaphore,
     *,
     timeout: float = 30.0,
+    verbose: bool | None = None,
 ) -> bool:
     """Render a single mermaid block using the CLI asynchronously.
 
@@ -225,6 +228,7 @@ async def render_block(
         idx: Index of the block within ``path``.
         semaphore: Limits concurrent CLI invocations.
         timeout: Maximum time in seconds to wait for the CLI to finish.
+        verbose: Deprecated. Configure logging to control command emission.
 
     Returns
     -------
@@ -234,6 +238,12 @@ async def render_block(
     -----
         The command line used for rendering is logged at ``INFO`` level.
     """
+    if verbose is not None:
+        warnings.warn(
+            "render_block(verbose=...) is deprecated; configure logging level instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     try:
         await _render_diagram(block, tmpdir, cfg_path, path, idx, semaphore, timeout)
     except FileNotFoundError as exc:
@@ -347,3 +357,4 @@ def cli() -> None:
 
 if __name__ == "__main__":
     cli()
+

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -229,23 +229,33 @@ async def render_block(
 ) -> bool:
     """Render a single mermaid block using the CLI asynchronously.
 
-    Args:
-        block: Mermaid code block to render.
-        tmpdir: Temporary directory for intermediate files.
-        cfg_path: Path to the Puppeteer configuration file.
-        path: Markdown file containing the block.
-        idx: Index of the block within ``path``.
-        semaphore: Limits concurrent CLI invocations.
-        timeout: Maximum time in seconds to wait for the CLI to finish.
-        verbose: Deprecated. Configure the ``nixie.cli`` logger instead.
+    Parameters
+    ----------
+    block : str
+        Mermaid code block to render.
+    tmpdir : Path
+        Temporary directory for intermediate files.
+    cfg_path : Path
+        Path to the Puppeteer configuration file.
+    path : Path
+        Markdown file containing the block.
+    idx : int
+        Index of the block within ``path``.
+    semaphore : asyncio.Semaphore
+        Limits concurrent CLI invocations.
+    timeout : float, default 30.0
+        Maximum time in seconds to wait for the CLI to finish.
+    verbose : bool, optional
+        Deprecated; configure the ``nixie.cli`` logger instead.
 
     Returns
     -------
+    bool
         ``True`` on success, ``False`` otherwise.
 
     Notes
     -----
-        The command line used for rendering is logged at ``INFO`` level.
+    The command line used for rendering is logged at ``INFO`` level.
     """
     if verbose is not None:
         warnings.warn(
@@ -263,11 +273,9 @@ async def render_block(
             cli,
         )
     except RuntimeError:
-        logging.getLogger(__name__).exception(
-            "Runtime error while rendering diagram"
-        )
+        logging.getLogger(__name__).exception("Runtime error while rendering diagram")
     except Exception as exc:
-        if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+        if isinstance(exc, KeyboardInterrupt | SystemExit):
             raise
         logging.getLogger(__name__).exception(
             "%s: unexpected error in diagram %s",

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -27,6 +27,7 @@ import sys
 import tempfile
 import typing
 import typing as typ
+import warnings
 from contextlib import contextmanager, suppress
 from pathlib import Path
 
@@ -236,8 +237,7 @@ async def render_block(
         idx: Index of the block within ``path``.
         semaphore: Limits concurrent CLI invocations.
         timeout: Maximum time in seconds to wait for the CLI to finish.
-        verbose: If ``True``, set the ``nixie.cli`` logger to ``INFO`` to
-            emit command lines. Preserved for backward compatibility.
+        verbose: Deprecated. Configure the ``nixie.cli`` logger instead.
 
     Returns
     -------
@@ -247,31 +247,28 @@ async def render_block(
     -----
         The command line used for rendering is logged at ``INFO`` level.
     """
-    if verbose:
-        logging.getLogger(__name__).setLevel(logging.INFO)
+    if verbose is not None:
+        warnings.warn(
+            "The 'verbose' parameter is deprecated; configure the 'nixie.cli'"
+            " logger level instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     try:
         await _render_diagram(block, tmpdir, cfg_path, path, idx, semaphore, timeout)
     except FileNotFoundError as exc:
         cli = exc.filename or "mmdc"
-<<<<<<< HEAD
-        print(
-            "Error: "
-            f"'{cli}' not found. Install Node.js with npx or Bun to use "
-            "@mermaid-js/mermaid-cli.",
-            file=sys.stderr,
-||||||| parent of c8480b7 (Log rendering errors with tracebacks)
         logging.getLogger(__name__).error(
             "Error: '%s' not found. Install Node.js with npx or Bun to use @mermaid-js/mermaid-cli.",
             cli,
-=======
-        logging.getLogger(__name__).exception(
-            "Error: '%s' not found. Install Node.js with npx or Bun to use @mermaid-js/mermaid-cli.",
-            cli,
->>>>>>> c8480b7 (Log rendering errors with tracebacks)
         )
     except RuntimeError:
-        logging.getLogger(__name__).exception("Runtime error while rendering diagram")
-    except Exception:
+        logging.getLogger(__name__).exception(
+            "Runtime error while rendering diagram"
+        )
+    except Exception as exc:
+        if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+            raise
         logging.getLogger(__name__).exception(
             "%s: unexpected error in diagram %s",
             path,

--- a/nixie/unittests/test_render_diagram.py
+++ b/nixie/unittests/test_render_diagram.py
@@ -24,7 +24,7 @@ async def test_render_diagram_writes_file_and_logs(
     path = Path("doc.md")
     block = "A-->B"
 
-    async def fake_create_subprocess_exec(*cmd: str, **_kwargs: object) -> object:
+    async def fake_create_subprocess_exec(*_cmd: str, **_kwargs: object) -> object:
         return object()
 
     async def fake_wait_for_proc(
@@ -58,7 +58,7 @@ async def test_render_diagram_raises_on_failure(
     path = Path("doc.md")
     block = "A-->B"
 
-    async def fake_create_subprocess_exec(*cmd: str, **_kwargs: object) -> object:
+    async def fake_create_subprocess_exec(*_cmd: str, **_kwargs: object) -> object:
         return object()
 
     async def fake_wait_for_proc(

--- a/nixie/unittests/test_render_diagram.py
+++ b/nixie/unittests/test_render_diagram.py
@@ -30,6 +30,7 @@ async def test_render_diagram_writes_file_and_logs(
     async def fake_wait_for_proc(
         proc: object, path: Path, idx: int, timeout: float
     ) -> tuple[bool, bytes]:
+        assert semaphore.locked()
         return True, b""
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
@@ -63,6 +64,7 @@ async def test_render_diagram_raises_on_failure(
     async def fake_wait_for_proc(
         proc: object, path: Path, idx: int, timeout: float
     ) -> tuple[bool, bytes]:
+        assert semaphore.locked()
         return False, b"Parse error on line 1:\nfoo\n^\n"
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)

--- a/nixie/unittests/test_render_diagram.py
+++ b/nixie/unittests/test_render_diagram.py
@@ -24,11 +24,11 @@ async def test_render_diagram_writes_file_and_logs(
     path = Path("doc.md")
     block = "A-->B"
 
-    async def fake_create_subprocess_exec(*cmd: str, **kwargs: object) -> object:
+    async def fake_create_subprocess_exec(*cmd: str, **_kwargs: object) -> object:
         return object()
 
     async def fake_wait_for_proc(
-        proc: object, path: Path, idx: int, timeout: float
+        _proc: object, _path: Path, _idx: int, _timeout: float
     ) -> tuple[bool, bytes]:
         assert semaphore.locked()
         return True, b""
@@ -58,11 +58,11 @@ async def test_render_diagram_raises_on_failure(
     path = Path("doc.md")
     block = "A-->B"
 
-    async def fake_create_subprocess_exec(*cmd: str, **kwargs: object) -> object:
+    async def fake_create_subprocess_exec(*cmd: str, **_kwargs: object) -> object:
         return object()
 
     async def fake_wait_for_proc(
-        proc: object, path: Path, idx: int, timeout: float
+        _proc: object, _path: Path, _idx: int, _timeout: float
     ) -> tuple[bool, bytes]:
         assert semaphore.locked()
         return False, b"Parse error on line 1:\nfoo\n^\n"

--- a/nixie/unittests/test_verbose.py
+++ b/nixie/unittests/test_verbose.py
@@ -57,7 +57,7 @@ async def test_render_block_emits_command(
 
 
 @pytest.mark.asyncio
-async def test_render_block_verbose_sets_logger(
+async def test_render_block_verbose_deprecated(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
@@ -81,15 +81,16 @@ async def test_render_block_verbose_sets_logger(
 
     block = "A-->B"
     logging.getLogger("nixie.cli").setLevel(logging.WARNING)
-    caplog.set_level(logging.INFO)
-    assert await render_block(
-        block, tmp_path, cfg_path, path, 1, semaphore, verbose=True
-    )
+    with pytest.warns(DeprecationWarning):
+        with caplog.at_level(logging.WARNING, logger="nixie.cli"):
+            assert await render_block(
+                block, tmp_path, cfg_path, path, 1, semaphore, verbose=True
+            )
 
     mmd = tmp_path / "doc_1.mmd"
     svg = mmd.with_suffix(".svg")
-    expected = shlex.join(get_mmdc_cmd(mmd, svg, cfg_path))
-    assert expected in caplog.text
+    unexpected = shlex.join(get_mmdc_cmd(mmd, svg, cfg_path))
+    assert unexpected not in caplog.text
 
 
 @pytest.mark.asyncio
@@ -149,3 +150,51 @@ async def test_render_block_logs_missing_cli(
 
     assert result is False
     assert "not found" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_render_block_logs_runtime_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text("{}")
+    semaphore = asyncio.Semaphore(1)
+    path = tmp_path / "doc.md"
+
+    async def raise_runtime_error(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("nixie.cli._render_diagram", raise_runtime_error)
+
+    block = "A-->B"
+    with caplog.at_level(logging.ERROR, logger="nixie.cli"):
+        result = await render_block(block, tmp_path, cfg_path, path, 1, semaphore)
+
+    assert result is False
+    assert "Runtime error while rendering diagram" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_render_block_logs_unexpected_exception(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text("{}")
+    semaphore = asyncio.Semaphore(1)
+    path = tmp_path / "doc.md"
+
+    async def raise_exception(*_args: object, **_kwargs: object) -> None:
+        raise Exception("uh oh")
+
+    monkeypatch.setattr("nixie.cli._render_diagram", raise_exception)
+
+    block = "A-->B"
+    with caplog.at_level(logging.ERROR, logger="nixie.cli"):
+        result = await render_block(block, tmp_path, cfg_path, path, 1, semaphore)
+
+    assert result is False
+    assert "unexpected error in diagram" in caplog.text

--- a/nixie/unittests/test_verbose.py
+++ b/nixie/unittests/test_verbose.py
@@ -81,11 +81,13 @@ async def test_render_block_verbose_deprecated(
 
     block = "A-->B"
     logging.getLogger("nixie.cli").setLevel(logging.WARNING)
-    with pytest.warns(DeprecationWarning):
-        with caplog.at_level(logging.WARNING, logger="nixie.cli"):
-            assert await render_block(
-                block, tmp_path, cfg_path, path, 1, semaphore, verbose=True
-            )
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"The 'verbose' parameter is deprecated; configure the 'nixie\.cli' logger level instead\.",
+    ), caplog.at_level(logging.WARNING, logger="nixie.cli"):
+        assert await render_block(
+            block, tmp_path, cfg_path, path, 1, semaphore, verbose=True,
+        )
 
     mmd = tmp_path / "doc_1.mmd"
     svg = mmd.with_suffix(".svg")
@@ -187,8 +189,11 @@ async def test_render_block_logs_unexpected_exception(
     semaphore = asyncio.Semaphore(1)
     path = tmp_path / "doc.md"
 
+    class BoomError(Exception):
+        pass
+
     async def raise_exception(*_args: object, **_kwargs: object) -> None:
-        raise Exception("uh oh")
+        raise BoomError("uh oh")
 
     monkeypatch.setattr("nixie.cli._render_diagram", raise_exception)
 

--- a/nixie/unittests/test_verbose.py
+++ b/nixie/unittests/test_verbose.py
@@ -34,7 +34,7 @@ async def test_render_block_emits_command(
     semaphore = asyncio.Semaphore(1)
     path = tmp_path / "doc.md"
 
-    async def fake_create_subprocess_exec(*cmd: str, **_kwargs: object) -> object:
+    async def fake_create_subprocess_exec(*_cmd: str, **_kwargs: object) -> object:
         return object()
 
     async def fake_wait_for_proc(
@@ -67,7 +67,7 @@ async def test_render_block_verbose_sets_logger(
     semaphore = asyncio.Semaphore(1)
     path = tmp_path / "doc.md"
 
-    async def fake_create_subprocess_exec(*cmd: str, **_kwargs: object) -> object:
+    async def fake_create_subprocess_exec(*_cmd: str, **_kwargs: object) -> object:
         return object()
 
     async def fake_wait_for_proc(
@@ -104,7 +104,7 @@ async def test_render_block_silent_without_verbose(
     semaphore = asyncio.Semaphore(1)
     path = tmp_path / "doc.md"
 
-    async def fake_create_subprocess_exec(*cmd: str, **_kwargs: object) -> object:
+    async def fake_create_subprocess_exec(*_cmd: str, **_kwargs: object) -> object:
         return object()
 
     async def fake_wait_for_proc(
@@ -137,8 +137,8 @@ async def test_render_block_logs_missing_cli(
     semaphore = asyncio.Semaphore(1)
     path = tmp_path / "doc.md"
 
-    async def fake_create_subprocess_exec(*cmd: str, **_kwargs: object) -> object:
-        raise FileNotFoundError(2, "No such file or directory", cmd[0])
+    async def fake_create_subprocess_exec(*_cmd: str, **_kwargs: object) -> object:
+        raise FileNotFoundError(2, "No such file or directory", _cmd[0])
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
     monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/mmdc")

--- a/nixie/unittests/test_verbose.py
+++ b/nixie/unittests/test_verbose.py
@@ -62,6 +62,7 @@ async def test_render_block_verbose_deprecated(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    """Test deprecated verbose parameter still works but warns."""
     cfg_path = tmp_path / "cfg.json"
     cfg_path.write_text("{}")
     semaphore = asyncio.Semaphore(1)
@@ -84,7 +85,10 @@ async def test_render_block_verbose_deprecated(
     with (
         pytest.warns(
             DeprecationWarning,
-            match=r"The 'verbose' parameter is deprecated; configure the 'nixie\.cli' logger level instead\.",
+            match=(
+                r"The 'verbose' parameter is deprecated; configure the"
+                r"'nixie\.cli' logger level instead\."
+            ),
         ),
         caplog.at_level(logging.WARNING, logger="nixie.cli"),
     ):
@@ -144,6 +148,7 @@ async def test_render_block_logs_missing_cli(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    """Log error when CLI tool is missing."""
     cfg_path = tmp_path / "cfg.json"
     cfg_path.write_text("{}")
     semaphore = asyncio.Semaphore(1)
@@ -169,6 +174,7 @@ async def test_render_block_logs_runtime_error(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    """Log runtime errors during diagram rendering."""
     cfg_path = tmp_path / "cfg.json"
     cfg_path.write_text("{}")
     semaphore = asyncio.Semaphore(1)
@@ -193,16 +199,17 @@ async def test_render_block_logs_unexpected_exception(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    """Log unexpected exceptions during diagram rendering."""
     cfg_path = tmp_path / "cfg.json"
     cfg_path.write_text("{}")
     semaphore = asyncio.Semaphore(1)
     path = tmp_path / "doc.md"
 
     class BoomError(Exception):
-        pass
+        """Uh oh."""
 
     async def raise_exception(*_args: object, **_kwargs: object) -> None:
-        raise BoomError("uh oh")
+        raise BoomError
 
     monkeypatch.setattr("nixie.cli._render_diagram", raise_exception)
 

--- a/nixie/unittests/test_verbose.py
+++ b/nixie/unittests/test_verbose.py
@@ -57,9 +57,10 @@ async def test_render_block_emits_command(
 
 
 @pytest.mark.asyncio
-async def test_render_block_warns_on_verbose(
+async def test_render_block_verbose_sets_logger(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     cfg_path = tmp_path / "cfg.json"
     cfg_path.write_text("{}")
@@ -79,10 +80,16 @@ async def test_render_block_warns_on_verbose(
     monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/mmdc")
 
     block = "A-->B"
-    with pytest.warns(DeprecationWarning):
-        assert await render_block(
-            block, tmp_path, cfg_path, path, 1, semaphore, verbose=True
-        )
+    logging.getLogger("nixie.cli").setLevel(logging.WARNING)
+    caplog.set_level(logging.INFO)
+    assert await render_block(
+        block, tmp_path, cfg_path, path, 1, semaphore, verbose=True
+    )
+
+    mmd = tmp_path / "doc_1.mmd"
+    svg = mmd.with_suffix(".svg")
+    expected = shlex.join(get_mmdc_cmd(mmd, svg, cfg_path))
+    assert expected in caplog.text
 
 
 @pytest.mark.asyncio

--- a/nixie/unittests/test_verbose.py
+++ b/nixie/unittests/test_verbose.py
@@ -34,11 +34,11 @@ async def test_render_block_emits_command(
     semaphore = asyncio.Semaphore(1)
     path = tmp_path / "doc.md"
 
-    async def fake_create_subprocess_exec(*cmd: str, **kwargs: object) -> object:
+    async def fake_create_subprocess_exec(*cmd: str, **_kwargs: object) -> object:
         return object()
 
     async def fake_wait_for_proc(
-        proc: object, path: Path, idx: int, timeout: float
+        _proc: object, _path: Path, _idx: int, _timeout: float
     ) -> tuple[bool, bytes]:
         return True, b""
 
@@ -57,7 +57,36 @@ async def test_render_block_emits_command(
 
 
 @pytest.mark.asyncio
-async def test_render_block_silent_when_warning_level(
+async def test_render_block_warns_on_verbose(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text("{}")
+    semaphore = asyncio.Semaphore(1)
+    path = tmp_path / "doc.md"
+
+    async def fake_create_subprocess_exec(*cmd: str, **_kwargs: object) -> object:
+        return object()
+
+    async def fake_wait_for_proc(
+        _proc: object, _path: Path, _idx: int, _timeout: float
+    ) -> tuple[bool, bytes]:
+        return True, b""
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr("nixie.cli.wait_for_proc", fake_wait_for_proc)
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/mmdc")
+
+    block = "A-->B"
+    with pytest.warns(DeprecationWarning):
+        assert await render_block(
+            block, tmp_path, cfg_path, path, 1, semaphore, verbose=True
+        )
+
+
+@pytest.mark.asyncio
+async def test_render_block_silent_without_verbose(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
@@ -68,11 +97,11 @@ async def test_render_block_silent_when_warning_level(
     semaphore = asyncio.Semaphore(1)
     path = tmp_path / "doc.md"
 
-    async def fake_create_subprocess_exec(*cmd: str, **kwargs: object) -> object:
+    async def fake_create_subprocess_exec(*cmd: str, **_kwargs: object) -> object:
         return object()
 
     async def fake_wait_for_proc(
-        proc: object, path: Path, idx: int, timeout: float
+        _proc: object, _path: Path, _idx: int, _timeout: float
     ) -> tuple[bool, bytes]:
         return True, b""
 
@@ -101,7 +130,7 @@ async def test_render_block_logs_missing_cli(
     semaphore = asyncio.Semaphore(1)
     path = tmp_path / "doc.md"
 
-    async def fake_create_subprocess_exec(*cmd: str, **kwargs: object) -> object:
+    async def fake_create_subprocess_exec(*cmd: str, **_kwargs: object) -> object:
         raise FileNotFoundError(2, "No such file or directory", cmd[0])
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)

--- a/nixie/unittests/test_verbose.py
+++ b/nixie/unittests/test_verbose.py
@@ -81,12 +81,21 @@ async def test_render_block_verbose_deprecated(
 
     block = "A-->B"
     logging.getLogger("nixie.cli").setLevel(logging.WARNING)
-    with pytest.warns(
-        DeprecationWarning,
-        match=r"The 'verbose' parameter is deprecated; configure the 'nixie\.cli' logger level instead\.",
-    ), caplog.at_level(logging.WARNING, logger="nixie.cli"):
+    with (
+        pytest.warns(
+            DeprecationWarning,
+            match=r"The 'verbose' parameter is deprecated; configure the 'nixie\.cli' logger level instead\.",
+        ),
+        caplog.at_level(logging.WARNING, logger="nixie.cli"),
+    ):
         assert await render_block(
-            block, tmp_path, cfg_path, path, 1, semaphore, verbose=True,
+            block,
+            tmp_path,
+            cfg_path,
+            path,
+            1,
+            semaphore,
+            verbose=True,
         )
 
     mmd = tmp_path / "doc_1.mmd"

--- a/nixie/unittests/test_verbose.py
+++ b/nixie/unittests/test_verbose.py
@@ -88,3 +88,28 @@ async def test_render_block_silent_when_warning_level(
     svg = mmd.with_suffix(".svg")
     unexpected = shlex.join(get_mmdc_cmd(mmd, svg, cfg_path))
     assert unexpected not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_render_block_logs_missing_cli(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text("{}")
+    semaphore = asyncio.Semaphore(1)
+    path = tmp_path / "doc.md"
+
+    async def fake_create_subprocess_exec(*cmd: str, **kwargs: object) -> object:
+        raise FileNotFoundError(2, "No such file or directory", cmd[0])
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/mmdc")
+
+    block = "A-->B"
+    with caplog.at_level(logging.ERROR, logger="nixie.cli"):
+        result = await render_block(block, tmp_path, cfg_path, path, 1, semaphore)
+
+    assert result is False
+    assert "not found" in caplog.text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,18 @@ select = [
     "D",
     "ANN",
 ]
-per-file-ignores = {"**/test_*.py" = ["S101"]}
+ignore = ["D205"]
+
+[tool.ruff.lint.per-file-ignores]
+"**/test_*.py" = [
+  "S101",  # allow assert in tests
+  "D",     # skip docstring rules in tests
+  "ANN",   # skip type-annotation rules in tests
+  "TRY003",# allow messages in exceptions for tests
+  "E501",  # allow long lines (e.g., regex) in tests
+  "I001",  # be lenient on import sorting in tests
+]
+"tests/**/conftest.py" = ["D", "ANN", "TRY003"]
 ignore = ["D205"]
 
 [tool.ruff.lint.flake8-import-conventions]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,12 +77,11 @@ ignore = ["D205"]
 "**/test_*.py" = [
   "S101",  # allow assert in tests
   "D",     # skip docstring rules in tests
-  "ANN",   # skip type-annotation rules in tests
   "TRY003",# allow messages in exceptions for tests
   "E501",  # allow long lines (e.g., regex) in tests
   "I001",  # be lenient on import sorting in tests
 ]
-"tests/**/conftest.py" = ["D", "ANN", "TRY003"]
+"tests/**/conftest.py" = ["D", "TRY003"]
 ignore = ["D205"]
 
 [tool.ruff.lint.flake8-import-conventions]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,10 +76,6 @@ ignore = ["D205"]
 [tool.ruff.lint.per-file-ignores]
 "**/test_*.py" = [
   "S101",  # allow assert in tests
-  "D",     # skip docstring rules in tests
-  "TRY003",# allow messages in exceptions for tests
-  "E501",  # allow long lines (e.g., regex) in tests
-  "I001",  # be lenient on import sorting in tests
 ]
 "tests/**/conftest.py" = ["D", "TRY003"]
 ignore = ["D205"]


### PR DESCRIPTION
## Summary
- enforce semaphore for full diagram rendering
- restore deprecated verbose parameter with warning
- log missing CLI via logger.error

## Testing
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68951fda2d408322bc1063416fdd0797

## Summary by Sourcery

Enforce semaphore locking throughout the diagram rendering process, reinstate the deprecated verbose parameter with logging-based warnings, replace print-based error reports with logger.exception calls, and update the CLI and documentation to reflect these changes.

New Features:
- Restore the deprecated verbose parameter in render_block for backward compatibility, enabling INFO-level logging of the underlying mermaid-cli commands when set
- Allow the --verbose CLI flag to set the nixie.cli logger to INFO instead of adjusting basicConfig

Bug Fixes:
- Use logger.exception to report missing mermaid-cli (FileNotFoundError) and runtime errors instead of printing to stderr

Enhancements:
- Rename the sem parameter to semaphore in _render_diagram and enforce its lock across both process creation and waiting
- Default CLI logging level to WARNING and adjust only the nixie.cli logger for verbosity

Documentation:
- Update README and add a changelog entry to document the revised verbose flag behavior

Tests:
- Add unit tests for verbose logging, silent mode, and missing CLI error logging