### PR TITLE
Fix lint issues across codebase

### DIFF
--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -34,7 +34,21 @@ BLOCK_RE = re.compile(
     re.DOTALL | re.MULTILINE,
 )
 
-ALLOWED_EXECUTABLES: typing.Final[frozenset[str]] = frozenset({"mmdc", "bun", "npx"})
+ALLOWED_EXECUTABLES: typ.Final[frozenset[str]] = frozenset({"mmdc", "bun", "npx"})
+
+
+class UnexpectedExecutableError(ValueError):
+    """Raised when an executable outside the allowed set is requested."""
+
+    def __init__(self, executable: str) -> None:
+        super().__init__(f"Unexpected executable: {executable}")
+
+
+class ConcurrencyValueError(argparse.ArgumentTypeError):
+    """Raised when a concurrency value less than one is supplied."""
+
+    def __init__(self, value: str) -> None:
+        super().__init__(f"concurrency must be at least 1 (got {value})")
 
 
 def parse_blocks(text: str) -> list[str]:
@@ -65,7 +79,7 @@ def create_puppeteer_config() -> typ.Generator[Path]:
         yield path
     finally:
         with suppress(OSError):
-            os.remove(path)
+            path.unlink()
 
 
 def get_mmdc_cmd(mmd: Path, svg: Path, cfg_path: Path) -> list[str]:
@@ -121,10 +135,11 @@ async def _run_mermaid_cli(
     timeout: float,
 ) -> tuple[bool, bytes]:
     if not cmd or cmd[0] not in ALLOWED_EXECUTABLES:
-        raise ValueError(f"Unexpected executable: {cmd[0] if cmd else ''}")
+        raise UnexpectedExecutableError(cmd[0] if cmd else "")
 
     async with sem:
-        proc = await asyncio.create_subprocess_exec(  # nosemgrep: python.lang.security.audit.dangerous-asyncio-create-exec-audit
+        # nosemgrep: python.lang.security.audit.dangerous-asyncio-create-exec-audit
+        proc = await asyncio.create_subprocess_exec(
             *cmd,
             stdout=asyncio_subprocess.PIPE,
             stderr=asyncio_subprocess.PIPE,
@@ -177,7 +192,7 @@ async def _render_diagram(
 
     cmd = get_mmdc_cmd(mmd, svg, cfg_path)
     if not cmd or cmd[0] not in ALLOWED_EXECUTABLES:
-        raise ValueError(f"Unexpected executable: {cmd[0] if cmd else ''}")
+        raise UnexpectedExecutableError(cmd[0] if cmd else "")
     logging.getLogger(__name__).info(shlex.join(cmd))
 
     success, stderr = await _run_mermaid_cli(cmd, sem, path, idx, timeout)
@@ -224,7 +239,9 @@ async def render_block(
     except FileNotFoundError as exc:
         cli = exc.filename or "mmdc"
         print(
-            f"Error: '{cli}' not found. Install Node.js with npx or Bun to use @mermaid-js/mermaid-cli.",
+            "Error: "
+            f"'{cli}' not found. Install Node.js with npx or Bun to use "
+            "@mermaid-js/mermaid-cli.",
             file=sys.stderr,
         )
     except RuntimeError as exc:
@@ -266,8 +283,8 @@ async def check_file(
     return all(result is True for result in results)
 
 
-async def main(paths, max_concurrent) -> int:
-    """Main entry point."""
+async def main(paths: cabc.Iterable[Path], max_concurrent: int) -> int:
+    """Run the CLI entry point."""
     semaphore = asyncio.Semaphore(max_concurrent)
     with create_puppeteer_config() as cfg_path:
         all_success = True
@@ -275,7 +292,8 @@ async def main(paths, max_concurrent) -> int:
             print(f"==> {path}")
             try:
                 success = await check_file(path, cfg_path, semaphore)
-            except Exception as exc:  # pragma: no cover - unexpected
+            except Exception as exc:  # noqa: BLE001  pragma: no cover - unexpected
+                # Catch unexpected errors so the CLI can continue processing.
                 print(f"Validation task raised an exception: {exc}")
                 success = False
             if not success:
@@ -288,9 +306,7 @@ def positive_int(value: str) -> int:
     """Type for argparse to ensure a positive integer (>=1)."""
     ivalue = int(value)
     if ivalue < 1:
-        raise argparse.ArgumentTypeError(
-            f"concurrency must be at least 1 (got {value})"
-        )
+        raise ConcurrencyValueError(value)
     return ivalue
 
 

--- a/nixie/unittests/test_get_mmdc_cmd.py
+++ b/nixie/unittests/test_get_mmdc_cmd.py
@@ -1,3 +1,5 @@
+"""Unit tests for :mod:`nixie.cli.get_mmdc_cmd`."""
+
 import shutil
 from pathlib import Path
 
@@ -8,6 +10,7 @@ from nixie.cli import get_mmdc_cmd
 
 @pytest.fixture
 def sample_paths(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Return sample mmd, svg, and config paths."""
     mmd = tmp_path / "diagram.mmd"
     svg = tmp_path / "diagram.svg"
     cfg = tmp_path / "cfg.json"
@@ -15,8 +18,9 @@ def sample_paths(tmp_path: Path) -> tuple[Path, Path, Path]:
 
 
 def test_get_mmdc_cmd_with_bun(
-    monkeypatch, sample_paths: tuple[Path, Path, Path]
+    monkeypatch: pytest.MonkeyPatch, sample_paths: tuple[Path, Path, Path]
 ) -> None:
+    """Use Bun executable when available."""
     mmd, svg, cfg = sample_paths
 
     def which(cmd: str) -> str | None:
@@ -31,8 +35,9 @@ def test_get_mmdc_cmd_with_bun(
 
 
 def test_get_mmdc_cmd_with_npx(
-    monkeypatch, sample_paths: tuple[Path, Path, Path]
+    monkeypatch: pytest.MonkeyPatch, sample_paths: tuple[Path, Path, Path]
 ) -> None:
+    """Fallback to npx when neither bun nor mmdc is available."""
     mmd, svg, cfg = sample_paths
 
     monkeypatch.setattr(shutil, "which", lambda cmd: None)

--- a/nixie/unittests/test_parse_blocks.py
+++ b/nixie/unittests/test_parse_blocks.py
@@ -1,3 +1,5 @@
+"""Tests for ``parse_blocks`` utility."""
+
 import pytest
 
 from nixie.cli import parse_blocks
@@ -13,17 +15,21 @@ from nixie.cli import parse_blocks
     ],
 )
 def test_parse_blocks_variations(text: str) -> None:
+    """Handle minor formatting variations around Mermaid blocks."""
     assert parse_blocks(text) == ["A-->B"]
 
 
 def test_parse_blocks_multiple() -> None:
+    """Extract multiple Mermaid blocks from content."""
     content = "```mermaid\nA-->B\n```\n\n```mermaid\nC-->D\n```"
     assert parse_blocks(content) == ["A-->B", "C-->D"]
 
 
 def test_parse_blocks_none() -> None:
+    """Return an empty list when no blocks are present."""
     assert parse_blocks("No diagrams here") == []
 
 
 def test_parse_blocks_empty() -> None:
+    """Return an empty list for empty input."""
     assert parse_blocks("") == []

--- a/nixie/unittests/test_render_diagram.py
+++ b/nixie/unittests/test_render_diagram.py
@@ -1,4 +1,7 @@
+"""Tests for rendering diagrams via the CLI helpers."""
+
 from __future__ import annotations
+
 import asyncio
 import logging
 import shlex
@@ -7,13 +10,14 @@ from pathlib import Path
 
 import pytest
 
-from nixie.cli import _render_diagram, get_mmdc_cmd, _run_mermaid_cli
+from nixie.cli import _render_diagram, _run_mermaid_cli, get_mmdc_cmd
 
 
 @pytest.mark.asyncio
 async def test_render_diagram_writes_file_and_logs(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
+    """Write diagram to disk and log the CLI invocation."""
     cfg_path = tmp_path / "cfg.json"
     cfg_path.write_text("{}")
     semaphore = asyncio.Semaphore(1)
@@ -46,6 +50,7 @@ async def test_render_diagram_writes_file_and_logs(
 async def test_render_diagram_raises_on_failure(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
+    """Raise ``RuntimeError`` when the CLI reports failure."""
     cfg_path = tmp_path / "cfg.json"
     cfg_path.write_text("{}")
     semaphore = asyncio.Semaphore(1)
@@ -75,6 +80,7 @@ async def test_render_diagram_raises_on_failure(
 
 @pytest.mark.asyncio
 async def test_run_mermaid_cli_rejects_unexpected_executable() -> None:
+    """Reject executables outside the allowed set."""
     semaphore = asyncio.Semaphore(1)
     path = Path("doc.md")
     cmd = ["echo", "hello"]

--- a/nixie/unittests/test_verbose.py
+++ b/nixie/unittests/test_verbose.py
@@ -1,3 +1,5 @@
+"""Tests for verbose logging behavior."""
+
 from __future__ import annotations
 
 import asyncio
@@ -13,6 +15,7 @@ from nixie.cli import get_mmdc_cmd, parse_args, render_block
 
 
 def test_parse_args_verbose(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Parse the ``--verbose`` flag into the argument namespace."""
     monkeypatch.setattr(sys, "argv", ["nixie", "--verbose", "file.md"])
     parsed = parse_args()
     assert parsed.verbose is True
@@ -25,6 +28,7 @@ async def test_render_block_emits_command(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    """Log the CLI command when verbose logging is enabled."""
     cfg_path = tmp_path / "cfg.json"
     cfg_path.write_text("{}")
     semaphore = asyncio.Semaphore(1)
@@ -58,6 +62,7 @@ async def test_render_block_silent_when_warning_level(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    """Avoid emitting command when only warnings are logged."""
     cfg_path = tmp_path / "cfg.json"
     cfg_path.write_text("{}")
     semaphore = asyncio.Semaphore(1)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,3 +1,5 @@
+"""Common fixtures for integration tests."""
+
 import asyncio
 import sys
 from pathlib import Path
@@ -7,7 +9,9 @@ import pytest
 
 
 @pytest.fixture
-def stub_render(monkeypatch) -> AsyncMock:
+def stub_render(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    """Replace ``render_block`` with a stub for predictable results."""
+
     async def side_effect(
         block: str,
         tmpdir: Path,

--- a/tests/integration/test_cli_behavior.py
+++ b/tests/integration/test_cli_behavior.py
@@ -1,9 +1,19 @@
+"""Integration tests for the CLI's high-level behavior."""
+
+import asyncio
 from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
 
 from nixie.cli import main
+
+
+class SimulatedProcessingError(ValueError):
+    """Exception used to simulate processing failures in tests."""
+
+    def __init__(self) -> None:
+        super().__init__("Simulated processing error")
 
 
 @pytest.mark.asyncio
@@ -67,6 +77,7 @@ async def test_cli_behavior(
     error_substring: str | None,
     expected_calls: list[tuple[str, int]],
 ) -> None:
+    """Process various input structures and validate outcomes."""
     for rel, content in structure.items():
         dest = tmp_path / rel
         dest.parent.mkdir(parents=True, exist_ok=True)
@@ -94,6 +105,7 @@ async def test_cli_behavior(
 async def test_cli_marks_file_boundaries(
     tmp_path: Path, stub_render: AsyncMock, capsys: pytest.CaptureFixture[str]
 ) -> None:
+    """Emit clear boundary markers for each processed file."""
     file_a = tmp_path / "a.md"
     file_b = tmp_path / "b.md"
     file_a.write_text("```mermaid\nA-->B\n```")
@@ -123,6 +135,7 @@ async def test_cli_handles_file_processing_error(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
+    """Handle exceptions from ``check_file`` without halting processing."""
     file_a = tmp_path / "a.md"
     file_b = tmp_path / "b.md"
     file_a.write_text("```mermaid\nA-->B\n```")
@@ -132,10 +145,16 @@ async def test_cli_handles_file_processing_error(
 
     original_check_file = cli_module.check_file
 
-    async def mock_check_file(path: Path, *args, **kwargs) -> bool:
+    async def mock_check_file(
+        path: Path,
+        cfg_path: Path,
+        semaphore: asyncio.Semaphore,
+        *args: object,
+        **kwargs: object,
+    ) -> bool:
         if path == file_b:
-            raise ValueError("Simulated processing error")
-        return await original_check_file(path, *args, **kwargs)
+            raise SimulatedProcessingError
+        return await original_check_file(path, cfg_path, semaphore, *args, **kwargs)
 
     monkeypatch.setattr(cli_module, "check_file", mock_check_file)
 


### PR DESCRIPTION
## Summary
- introduce dedicated exception types and enforce safer CLI arguments
- replace os.remove with Path.unlink in temp file cleanup
- add missing docstrings and type annotations to test modules

## Testing
- `make lint`
- `make fmt`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68953a50c7988322ac772a01b981977d