### PR TITLE
Handle mermaid CLI timeouts and environment errors

### DIFF
--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -146,7 +146,7 @@ async def wait_for_proc(
     """Wait for a process to complete and return its success status and stderr."""
     try:
         _, stderr = await asyncio.wait_for(proc.communicate(), timeout)
-    except TimeoutError:
+    except asyncio.TimeoutError:  # noqa: UP041
         proc.kill()
         await proc.wait()
         print(f"{path}: diagram {idx} timed out", file=sys.stderr)
@@ -172,8 +172,7 @@ async def _run_mermaid_cli(
             stdout=asyncio_subprocess.PIPE,
             stderr=asyncio_subprocess.PIPE,
         )
-
-    return await wait_for_proc(proc, path, idx, timeout)
+        return await wait_for_proc(proc, path, idx, timeout)
 
 
 async def _render_diagram(
@@ -219,18 +218,8 @@ async def _render_diagram(
     mmd.write_text(block)
 
     cmd = get_mmdc_cmd(mmd, svg, cfg_path)
-    if not cmd or cmd[0] not in ALLOWED_EXECUTABLES:
-        raise UnexpectedExecutableError(cmd[0] if cmd else "")
     LOGGER.info(shlex.join(cmd))
-
-    async with semaphore:
-        # nosemgrep: python.lang.security.audit.dangerous-asyncio-create-exec-audit
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        success, stderr = await wait_for_proc(proc, path, idx, timeout)
+    success, stderr = await _run_mermaid_cli(cmd, semaphore, path, idx, timeout)
     if not success:
         error_message = (
             f"Error running command {shlex.join(cmd)} for file '{path}' "
@@ -298,6 +287,11 @@ async def render_block(
                 "@mermaid-js/mermaid-cli."
             ),
             cli,
+        )
+    except NoNodeEnvironmentAvailableError:
+        LOGGER.exception(
+            "No supported node environment found. Install mmdc directly, or install "
+            "Node.js (npx) or Bun to use @mermaid-js/mermaid-cli."
         )
     except RuntimeError:
         LOGGER.exception("Runtime error while rendering diagram")

--- a/nixie/unittests/test_puppeteer_config.py
+++ b/nixie/unittests/test_puppeteer_config.py
@@ -9,16 +9,22 @@ import typing as typ
 from nixie.cli import create_puppeteer_config
 
 if typ.TYPE_CHECKING:
+    from pathlib import Path
+
     import pytest
 
 
 def test_create_puppeteer_config_as_root(monkeypatch: pytest.MonkeyPatch) -> None:
     """Include sandbox-disabling args when running as root."""
     monkeypatch.setattr(os, "geteuid", lambda: 0)
+    path: Path | None = None
     with create_puppeteer_config() as cfg:
         assert cfg is not None
+        path = cfg
         data = json.loads(cfg.read_text())
         assert data["args"] == ["--no-sandbox", "--disable-setuid-sandbox"]
+    assert path is not None
+    assert not path.exists()
 
 
 def test_create_puppeteer_config_non_root(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/nixie/unittests/test_wait_for_proc.py
+++ b/nixie/unittests/test_wait_for_proc.py
@@ -1,0 +1,30 @@
+"""Tests for :func:`nixie.cli.wait_for_proc`."""
+
+from __future__ import annotations
+
+import asyncio
+import asyncio.subprocess as asyncio_subprocess
+import sys
+import typing as typ
+
+import pytest
+
+from nixie.cli import wait_for_proc
+
+if typ.TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.mark.asyncio
+async def test_wait_for_proc_times_out(tmp_path: Path) -> None:
+    """Return ``False`` when the process exceeds ``timeout``."""
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        "import time; time.sleep(1)",
+        stdout=asyncio_subprocess.PIPE,
+        stderr=asyncio_subprocess.PIPE,
+    )
+    success, stderr = await wait_for_proc(proc, tmp_path / "dummy.md", 1, timeout=0.01)
+    assert not success
+    assert stderr == b""


### PR DESCRIPTION
## Summary
- Catch `asyncio.TimeoutError` in `wait_for_proc` and reuse `_run_mermaid_cli` from `_render_diagram`
- Surface a clear message when no Node.js or Bun runtime is available
- Ensure temporary Puppeteer config files are cleaned up and add timeout test

## Testing
- `make fmt`
- `make check-fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689d160d9b3883229ef0b3ce662304f0