### PR TITLE
Scan working directory when no paths are provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ nixie [--concurrency N] [--verbose] [FILE ...]
 to the number of CPU cores or `4` if this cannot be determined). Paths can be
 files or directories. If no files are provided, nixie searches the current
 working directory for Markdown files, excluding paths matched by `.gitignore` in
-that directory.
+that directory. Discovery includes files with the `.md` extension
+(case-sensitive).
 
 Only the `.gitignore` file in the working directory is used; nested
 `.gitignore` files are ignored.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 ## Features
 
 - Recursively searches directories for Markdown files
+- Scans the current directory for Markdown files when run without arguments,
+  honouring `.gitignore`
 - Parses `mermaid` code blocks and uses `@mermaid-js/mermaid-cli` to validate
 - Runs checks concurrently for faster feedback
 - Prints clear error messages for failing diagrams
@@ -40,12 +42,14 @@ uv sync --include dev
 ## Usage
 
 ```bash
-nixie [--concurrency N] [--verbose] FILE [FILE...]
+nixie [--concurrency N] [--verbose] [FILE ...]
 ```
 
 `--concurrency` controls how many diagrams are processed in parallel (defaults
 to the number of CPU cores or `4` if this cannot be determined). Paths can be
-files or directories.
+files or directories. If no files are provided, nixie searches the current
+working directory for Markdown files, excluding directories listed in
+`.gitignore`.
 
 `--verbose` sets the `nixie.cli` logger to `INFO`, logging the exact
 `mermaid-cli` command for each diagram.

--- a/README.md
+++ b/README.md
@@ -47,9 +47,12 @@ nixie [--concurrency N] [--verbose] [FILE ...]
 
 `--concurrency` controls how many diagrams are processed in parallel (defaults
 to the number of CPU cores or `4` if this cannot be determined). Paths can be
-files or directories, and directory traversal honours `.gitignore`. If no files
-are provided, nixie searches the current working directory for Markdown files
-using the same ignore rules.
+files or directories. If no files are provided, nixie searches the current
+working directory for Markdown files, excluding paths matched by `.gitignore` in
+that directory.
+
+Only the `.gitignore` file in the working directory is used; nested
+`.gitignore` files are ignored.
 
 `--verbose` sets the `nixie.cli` logger to `INFO`, logging the exact
 `mermaid-cli` command for each diagram.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 ## Features
 
-- Recursively searches directories for Markdown files
-- Scans the current directory for Markdown files when run without arguments,
-  honouring `.gitignore`
+- Recursively searches directories for Markdown files while honouring
+  `.gitignore`
+- Scans the current directory for Markdown files when run without arguments
 - Parses `mermaid` code blocks and uses `@mermaid-js/mermaid-cli` to validate
 - Runs checks concurrently for faster feedback
 - Prints clear error messages for failing diagrams
@@ -47,9 +47,9 @@ nixie [--concurrency N] [--verbose] [FILE ...]
 
 `--concurrency` controls how many diagrams are processed in parallel (defaults
 to the number of CPU cores or `4` if this cannot be determined). Paths can be
-files or directories. If no files are provided, nixie searches the current
-working directory for Markdown files, excluding directories listed in
-`.gitignore`.
+files or directories, and directory traversal honours `.gitignore`. If no files
+are provided, nixie searches the current working directory for Markdown files
+using the same ignore rules.
 
 `--verbose` sets the `nixie.cli` logger to `INFO`, logging the exact
 `mermaid-cli` command for each diagram.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,5 +8,6 @@
    instead.
 - When run as root, nixie now invokes `mmdc` with a Puppeteer configuration
   that disables the sandbox (`--no-sandbox` and `--disable-setuid-sandbox`).
-- Running `nixie` without arguments now scans the current directory for Markdown
-  files, skipping paths matched by `.gitignore`.
+- Directory traversal now respects `.gitignore` patterns. When run without
+  arguments, nixie scans the current directory for Markdown files using the same
+  ignore rules.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,6 @@
    instead.
 - When run as root, nixie now invokes `mmdc` with a Puppeteer configuration
   that disables the sandbox (`--no-sandbox` and `--disable-setuid-sandbox`).
-- Directory traversal now respects `.gitignore` patterns. When run without
-  arguments, nixie scans the current directory for Markdown files with a `.md`
-  extension using the same ignore rules.
+- Directory traversal honours `.gitignore` patterns in the working directory only.
+  When run without arguments, nixie scans the current directory for Markdown files
+  using those ignore rules (nested `.gitignore` files are ignored).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,5 +9,5 @@
 - When run as root, nixie now invokes `mmdc` with a Puppeteer configuration
   that disables the sandbox (`--no-sandbox` and `--disable-setuid-sandbox`).
 - Directory traversal now respects `.gitignore` patterns. When run without
-  arguments, nixie scans the current directory for Markdown files using the same
-  ignore rules.
+  arguments, nixie scans the current directory for Markdown files with a `.md`
+  extension using the same ignore rules.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,3 +8,5 @@
    instead.
 - When run as root, nixie now invokes `mmdc` with a Puppeteer configuration
   that disables the sandbox (`--no-sandbox` and `--disable-setuid-sandbox`).
+- Running `nixie` without arguments now scans the current directory for Markdown
+  files, skipping paths matched by `.gitignore`.

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -6,7 +6,7 @@ them with the `mermaid-cli` tool. It supports concurrent rendering via
 `asyncio` and falls back between `mmdc`, `npx`, and `bun` executables.
 
 Usage:
-    nixie [--concurrency N] [--verbose] [path1.md [path2.md ...]]
+    nixie [--concurrency N] [--verbose] [FILE ...]
 
 The ``--verbose`` flag sets the ``nixie.cli`` logger to ``INFO`` to emit the
 underlying ``mermaid-cli`` commands.
@@ -76,7 +76,7 @@ def _load_gitignore_spec(root: Path) -> pathspec.PathSpec | None:
     gitignore = root / ".gitignore"
     if gitignore.is_file():
         return pathspec.PathSpec.from_lines(
-            "gitwildmatch", gitignore.read_text().splitlines()
+            "gitwildmatch", gitignore.read_text(encoding="utf-8").splitlines()
         )
     return None
 
@@ -414,7 +414,7 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         nargs="*",
         help=(
-            "Markdown files to validate. Defaults to all Markdown files in the "
+            "Markdown files to validate. Defaults to all .md files in the "
             "current directory. Files ignored by .gitignore are excluded from "
             "discovery."
         ),

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -71,41 +71,60 @@ def parse_blocks(text: str) -> list[str]:
     return BLOCK_RE.findall(text)
 
 
-def discover_markdown_files() -> cabc.Generator[Path]:
-    """Yield Markdown files under the current directory respecting ``.gitignore``."""
-    root = Path.cwd()
-    spec: pathspec.PathSpec | None = None
+def _load_gitignore_spec(root: Path) -> pathspec.PathSpec | None:
+    """Return a ``PathSpec`` built from ``root/.gitignore`` if it exists."""
     gitignore = root / ".gitignore"
     if gitignore.is_file():
-        spec = pathspec.PathSpec.from_lines(
+        return pathspec.PathSpec.from_lines(
             "gitwildmatch", gitignore.read_text().splitlines()
         )
-    for dirpath, dirnames, filenames in os.walk(root):
-        rel_dir = Path(dirpath).relative_to(root)
-        dirnames[:] = [
-            d
-            for d in dirnames
-            if d != ".git"
-            and not (spec and spec.match_file(f"{(rel_dir / d).as_posix()}/"))
-        ]
-        for name in filenames:
-            if not name.lower().endswith(".md"):
-                continue
-            path = Path(dirpath) / name
-            rel_path = path.relative_to(root).as_posix()
-            if spec and spec.match_file(rel_path):
-                continue
-            yield path
+    return None
+
+
+def discover_markdown_files() -> cabc.Generator[Path]:
+    """Yield Markdown files under the current directory respecting ``.gitignore``."""
+    yield from collect_markdown_files([Path.cwd()])
 
 
 def collect_markdown_files(paths: cabc.Iterable[Path]) -> cabc.Generator[Path]:
-    """Expand directories into Markdown files recursively."""
+    """Yield Markdown files under ``paths`` while honouring ``.gitignore``."""
+    root = Path.cwd()
+    spec = _load_gitignore_spec(root)
     for p in paths:
         if p.is_dir():
-            for md in p.rglob("*"):
-                if md.is_file() and md.suffix.lower() == ".md":
-                    yield md
+            for dirpath, dirnames, filenames in os.walk(p):
+                try:
+                    rel_dir = Path(dirpath).resolve().relative_to(root)
+                except ValueError:
+                    rel_dir = None
+                dirnames[:] = [
+                    d
+                    for d in dirnames
+                    if d != ".git"
+                    and not (
+                        spec
+                        and rel_dir
+                        and spec.match_file(f"{(rel_dir / d).as_posix()}/")
+                    )
+                ]
+                for name in filenames:
+                    if not name.lower().endswith(".md"):
+                        continue
+                    path = Path(dirpath) / name
+                    try:
+                        rel_path = path.resolve().relative_to(root).as_posix()
+                    except ValueError:
+                        rel_path = None
+                    if spec and rel_path and spec.match_file(rel_path):
+                        continue
+                    yield path
         else:
+            try:
+                rel_path = p.resolve().relative_to(root).as_posix()
+            except ValueError:
+                rel_path = None
+            if spec and rel_path and spec.match_file(rel_path):
+                continue
             yield p
 
 

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -414,9 +414,9 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         nargs="*",
         help=(
-            "Markdown files to validate. Defaults to all .md files in the "
-            "current directory. Files ignored by .gitignore are excluded from "
-            "discovery."
+            "Markdown files or directories to validate. Defaults to all .md "
+            "files in the current directory, excluding paths ignored by "
+            ".gitignore."
         ),
     )
     parser.add_argument(

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -88,6 +88,9 @@ def discover_markdown_files() -> cabc.Generator[Path]:
     # Use rglob with explicit sorting for deterministic results
     paths = sorted(root.rglob("*.md"))
     for path in paths:
+        # Skip VCS metadata directories
+        if ".git" in path.parts:
+            continue
         rel_path = path.relative_to(root).as_posix()
         if spec and spec.match_file(rel_path):
             continue
@@ -113,6 +116,9 @@ def collect_markdown_files(paths: cabc.Iterable[Path]) -> cabc.Generator[Path]:
                 rel_path = p.resolve().relative_to(root).as_posix()
             except ValueError:
                 rel_path = None
+            # Only process Markdown files when an explicit file is provided
+            if p.suffix.lower() != ".md":
+                continue
             if spec and rel_path and spec.match_file(rel_path):
                 continue
             yield p

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -422,9 +422,9 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         nargs="*",
         help=(
-            "Markdown files or directories to validate. Defaults to all .md "
-            "files in the current directory, excluding paths ignored by "
-            ".gitignore."
+            "Markdown files or directories to validate. When omitted, scans the "
+            "current directory for .md files (honouring the top-level .gitignore; "
+            "nested .gitignore files are ignored)."
         ),
     )
     parser.add_argument(

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -85,7 +85,9 @@ def discover_markdown_files() -> cabc.Generator[Path]:
     """Yield Markdown files under the current directory respecting ``.gitignore``."""
     root = Path.cwd()
     spec = _load_gitignore_spec(root)
-    for path in sorted(root.rglob("*.md")):
+    # Use rglob with explicit sorting for deterministic results
+    paths = sorted(root.rglob("*.md"))
+    for path in paths:
         rel_path = path.relative_to(root).as_posix()
         if spec and spec.match_file(rel_path):
             continue
@@ -443,7 +445,13 @@ def cli() -> None:
         logger.addHandler(handler)
         logger.propagate = False
     logger.setLevel(logging.INFO if parsed.verbose else logging.WARNING)
-    paths = parsed.paths or discover_markdown_files()
+    if parsed.paths:
+        paths = list(parsed.paths)
+    else:
+        paths = list(discover_markdown_files())
+        if not paths:
+            print("No Markdown files found.", file=sys.stderr)
+            sys.exit(0)
     sys.exit(asyncio.run(main(paths, parsed.concurrency)))
 
 

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -6,7 +6,7 @@ them with the `mermaid-cli` tool. It supports concurrent rendering via
 `asyncio` and falls back between `mmdc`, `npx`, and `bun` executables.
 
 Usage:
-    nixie [--concurrency N] [--verbose] path1.md [path2.md ...]
+    nixie [--concurrency N] [--verbose] [path1.md [path2.md ...]]
 
 The ``--verbose`` flag sets the ``nixie.cli`` logger to ``INFO`` to emit the
 underlying ``mermaid-cli`` commands.
@@ -29,6 +29,8 @@ import typing as typ
 import warnings
 from contextlib import contextmanager, suppress
 from pathlib import Path
+
+import pathspec
 
 if typ.TYPE_CHECKING:
     import collections.abc as cabc
@@ -67,6 +69,33 @@ class NoNodeEnvironmentAvailableError(RuntimeError):
 def parse_blocks(text: str) -> list[str]:
     """Return all mermaid code blocks found in the text."""
     return BLOCK_RE.findall(text)
+
+
+def discover_markdown_files() -> cabc.Generator[Path]:
+    """Yield Markdown files under the current directory respecting ``.gitignore``."""
+    root = Path.cwd()
+    spec: pathspec.PathSpec | None = None
+    gitignore = root / ".gitignore"
+    if gitignore.is_file():
+        spec = pathspec.PathSpec.from_lines(
+            "gitwildmatch", gitignore.read_text().splitlines()
+        )
+    for dirpath, dirnames, filenames in os.walk(root):
+        rel_dir = Path(dirpath).relative_to(root)
+        dirnames[:] = [
+            d
+            for d in dirnames
+            if d != ".git"
+            and not (spec and spec.match_file(f"{(rel_dir / d).as_posix()}/"))
+        ]
+        for name in filenames:
+            if not name.lower().endswith(".md"):
+                continue
+            path = Path(dirpath) / name
+            rel_path = path.relative_to(root).as_posix()
+            if spec and spec.match_file(rel_path):
+                continue
+            yield path
 
 
 def collect_markdown_files(paths: cabc.Iterable[Path]) -> cabc.Generator[Path]:
@@ -376,8 +405,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "paths",
         type=Path,
-        nargs="+",
-        help="Markdown files to validate",
+        nargs="*",
+        help=(
+            "Markdown files to validate. Defaults to all Markdown files in the "
+            "current directory."
+        ),
     )
     parser.add_argument(
         "--concurrency",
@@ -403,7 +435,8 @@ def cli() -> None:
         logger.addHandler(handler)
         logger.propagate = False
     logger.setLevel(logging.INFO if parsed.verbose else logging.WARNING)
-    sys.exit(asyncio.run(main(parsed.paths, parsed.concurrency)))
+    paths = parsed.paths or discover_markdown_files()
+    sys.exit(asyncio.run(main(paths, parsed.concurrency)))
 
 
 if __name__ == "__main__":

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -83,7 +83,13 @@ def _load_gitignore_spec(root: Path) -> pathspec.PathSpec | None:
 
 def discover_markdown_files() -> cabc.Generator[Path]:
     """Yield Markdown files under the current directory respecting ``.gitignore``."""
-    yield from collect_markdown_files([Path.cwd()])
+    root = Path.cwd()
+    spec = _load_gitignore_spec(root)
+    for path in sorted(root.rglob("*.md")):
+        rel_path = path.relative_to(root).as_posix()
+        if spec and spec.match_file(rel_path):
+            continue
+        yield path
 
 
 def collect_markdown_files(paths: cabc.Iterable[Path]) -> cabc.Generator[Path]:
@@ -92,32 +98,14 @@ def collect_markdown_files(paths: cabc.Iterable[Path]) -> cabc.Generator[Path]:
     spec = _load_gitignore_spec(root)
     for p in paths:
         if p.is_dir():
-            for dirpath, dirnames, filenames in os.walk(p):
+            for path in sorted(p.rglob("*.md")):
                 try:
-                    rel_dir = Path(dirpath).resolve().relative_to(root)
+                    rel_path = path.resolve().relative_to(root).as_posix()
                 except ValueError:
-                    rel_dir = None
-                dirnames[:] = [
-                    d
-                    for d in dirnames
-                    if d != ".git"
-                    and not (
-                        spec
-                        and rel_dir
-                        and spec.match_file(f"{(rel_dir / d).as_posix()}/")
-                    )
-                ]
-                for name in filenames:
-                    if not name.lower().endswith(".md"):
-                        continue
-                    path = Path(dirpath) / name
-                    try:
-                        rel_path = path.resolve().relative_to(root).as_posix()
-                    except ValueError:
-                        rel_path = None
-                    if spec and rel_path and spec.match_file(rel_path):
-                        continue
-                    yield path
+                    rel_path = None
+                if spec and rel_path and spec.match_file(rel_path):
+                    continue
+                yield path
         else:
             try:
                 rel_path = p.resolve().relative_to(root).as_posix()
@@ -427,7 +415,8 @@ def parse_args() -> argparse.Namespace:
         nargs="*",
         help=(
             "Markdown files to validate. Defaults to all Markdown files in the "
-            "current directory."
+            "current directory. Files ignored by .gitignore are excluded from "
+            "discovery."
         ),
     )
     parser.add_argument(

--- a/nixie/unittests/test_discover_markdown_files.py
+++ b/nixie/unittests/test_discover_markdown_files.py
@@ -61,7 +61,9 @@ def test_discover_markdown_files_handles_negation_and_order(cwd_tmp: Path) -> No
     (cwd_tmp / ".gitignore").write_text("ignored/\n!ignored/keep.md\n")
 
     found = list(discover_markdown_files())
-    assert found == [reincluded, root]
+    assert found == [reincluded, root], (
+        "Should re-include negated pattern and maintain sorted-by-path order"
+    )
 
 
 def test_discover_markdown_files_empty_directory(cwd_tmp: Path) -> None:
@@ -69,7 +71,7 @@ def test_discover_markdown_files_empty_directory(cwd_tmp: Path) -> None:
     (cwd_tmp / ".gitignore").write_text("\n")
 
     found = list(discover_markdown_files())
-    assert found == []
+    assert found == [], "Should yield no paths in an empty directory"
 
 
 def test_discover_markdown_files_ignores_nested_gitignore(cwd_tmp: Path) -> None:
@@ -83,7 +85,9 @@ def test_discover_markdown_files_ignores_nested_gitignore(cwd_tmp: Path) -> None
     (sub / ".gitignore").write_text("skip.md\n")
 
     found = list(discover_markdown_files())
-    assert set(found) == {keep, skip}
+    assert set(found) == {keep, skip}, (
+        "Should ignore nested .gitignore and include both files"
+    )
 
 
 def test_collect_markdown_files_respects_gitignore(cwd_tmp: Path) -> None:
@@ -97,4 +101,4 @@ def test_collect_markdown_files_respects_gitignore(cwd_tmp: Path) -> None:
     (cwd_tmp / ".gitignore").write_text("ignored/\n")
 
     found = list(collect_markdown_files([cwd_tmp]))
-    assert found == [keep]
+    assert found == [keep], "Should ignore ignored/ when expanding explicit directories"

--- a/nixie/unittests/test_discover_markdown_files.py
+++ b/nixie/unittests/test_discover_markdown_files.py
@@ -1,0 +1,30 @@
+"""Tests for ``discover_markdown_files``."""
+
+from __future__ import annotations
+
+import typing as typ
+
+from nixie.cli import discover_markdown_files
+
+if typ.TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+def test_discover_markdown_files_respects_gitignore(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Skip directories listed in ``.gitignore`` when searching for Markdown."""
+    keep = tmp_path / "keep.md"
+    ignored_dir = tmp_path / "ignored"
+    ignored_dir.mkdir()
+    skip = ignored_dir / "skip.md"
+    keep.write_text("ok")
+    skip.write_text("nope")
+    (tmp_path / ".gitignore").write_text("ignored/\n")
+
+    monkeypatch.chdir(tmp_path)
+
+    found = list(discover_markdown_files())
+    assert found == [keep]

--- a/nixie/unittests/test_discover_markdown_files.py
+++ b/nixie/unittests/test_discover_markdown_files.py
@@ -46,7 +46,7 @@ def test_discover_markdown_files_skips_root_file(cwd_tmp: Path) -> None:
 
 
 def test_discover_markdown_files_handles_negation_and_order(cwd_tmp: Path) -> None:
-    """Support re-inclusion patterns and yield deterministically."""
+    """Re-include negated patterns and yield results sorted by path (deterministic)."""
     ignored_dir = cwd_tmp / "ignored"
     ignored_dir.mkdir()
     reincluded = ignored_dir / "keep.md"

--- a/nixie/unittests/test_discover_markdown_files.py
+++ b/nixie/unittests/test_discover_markdown_files.py
@@ -46,7 +46,10 @@ def test_discover_markdown_files_skips_root_file(cwd_tmp: Path) -> None:
 
 
 def test_discover_markdown_files_handles_negation_and_order(cwd_tmp: Path) -> None:
-    """Re-include negated patterns and yield results sorted by path (deterministic)."""
+    """Re-include negated patterns and yield results sorted by path (deterministic).
+
+    Deterministic ordering keeps assertions stable.
+    """
     ignored_dir = cwd_tmp / "ignored"
     ignored_dir.mkdir()
     reincluded = ignored_dir / "keep.md"

--- a/nixie/unittests/test_discover_markdown_files.py
+++ b/nixie/unittests/test_discover_markdown_files.py
@@ -30,6 +30,71 @@ def test_discover_markdown_files_respects_gitignore(
     assert found == [keep]
 
 
+def test_discover_markdown_files_skips_root_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Skip files ignored at the repository root."""
+    keep = tmp_path / "keep.md"
+    skip = tmp_path / "skip.md"
+    keep.write_text("ok")
+    skip.write_text("nope")
+    (tmp_path / ".gitignore").write_text("skip.md\n")
+
+    monkeypatch.chdir(tmp_path)
+
+    found = list(discover_markdown_files())
+    assert found == [keep]
+
+
+def test_discover_markdown_files_handles_negation_and_order(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Support re-inclusion patterns and yield deterministically."""
+    ignored_dir = tmp_path / "ignored"
+    ignored_dir.mkdir()
+    reincluded = ignored_dir / "keep.md"
+    reincluded.write_text("keep")
+    skipped = ignored_dir / "skip.md"
+    skipped.write_text("skip")
+    root = tmp_path / "root.md"
+    root.write_text("root")
+    (tmp_path / ".gitignore").write_text("ignored/\n!ignored/keep.md\n")
+
+    monkeypatch.chdir(tmp_path)
+
+    found = list(discover_markdown_files())
+    assert found == [reincluded, root]
+
+
+def test_discover_markdown_files_empty_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Return no paths when the directory has no Markdown files."""
+    (tmp_path / ".gitignore").write_text("\n")
+    monkeypatch.chdir(tmp_path)
+
+    found = list(discover_markdown_files())
+    assert found == []
+
+
+def test_discover_markdown_files_ignores_nested_gitignore(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Nested ``.gitignore`` files are ignored."""
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    keep = sub / "keep.md"
+    skip = sub / "skip.md"
+    keep.write_text("ok")
+    skip.write_text("nope")
+    (sub / ".gitignore").write_text("skip.md\n")
+
+    monkeypatch.chdir(tmp_path)
+
+    found = list(discover_markdown_files())
+    assert set(found) == {keep, skip}
+
+
 def test_collect_markdown_files_respects_gitignore(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/nixie/unittests/test_discover_markdown_files.py
+++ b/nixie/unittests/test_discover_markdown_files.py
@@ -1,10 +1,10 @@
-"""Tests for ``discover_markdown_files``."""
+"""Tests for Markdown file discovery helpers."""
 
 from __future__ import annotations
 
 import typing as typ
 
-from nixie.cli import discover_markdown_files
+from nixie.cli import collect_markdown_files, discover_markdown_files
 
 if typ.TYPE_CHECKING:
     from pathlib import Path
@@ -27,4 +27,22 @@ def test_discover_markdown_files_respects_gitignore(
     monkeypatch.chdir(tmp_path)
 
     found = list(discover_markdown_files())
+    assert found == [keep]
+
+
+def test_collect_markdown_files_respects_gitignore(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Skip ignored paths when expanding explicit directories."""
+    keep = tmp_path / "keep.md"
+    ignored_dir = tmp_path / "ignored"
+    ignored_dir.mkdir()
+    skip = ignored_dir / "skip.md"
+    keep.write_text("ok")
+    skip.write_text("nope")
+    (tmp_path / ".gitignore").write_text("ignored/\n")
+
+    monkeypatch.chdir(tmp_path)
+
+    found = list(collect_markdown_files([tmp_path]))
     assert found == [keep]

--- a/nixie/unittests/test_discover_markdown_files.py
+++ b/nixie/unittests/test_discover_markdown_files.py
@@ -1,4 +1,13 @@
-"""Tests for Markdown file discovery helpers."""
+"""Tests for Markdown file discovery helpers.
+
+These tests exercise Gitignore-aware Markdown discovery helpers:
+
+- Only the repository root ``.gitignore`` is honoured; nested ``.gitignore`` files
+  are ignored.
+- Discovery yields results deterministically, sorted by path.
+- Both implicit discovery (CWD) and explicit directory expansion behave
+  consistently.
+"""
 
 from __future__ import annotations
 

--- a/nixie/unittests/test_discover_markdown_files.py
+++ b/nixie/unittests/test_discover_markdown_files.py
@@ -4,84 +4,74 @@ from __future__ import annotations
 
 import typing as typ
 
+import pytest
+
 from nixie.cli import collect_markdown_files, discover_markdown_files
 
 if typ.TYPE_CHECKING:
     from pathlib import Path
 
-    import pytest
+
+@pytest.fixture
+def cwd_tmp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Run tests from a temporary working directory."""
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
 
 
-def test_discover_markdown_files_respects_gitignore(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_discover_markdown_files_respects_gitignore(cwd_tmp: Path) -> None:
     """Skip directories listed in ``.gitignore`` when searching for Markdown."""
-    keep = tmp_path / "keep.md"
-    ignored_dir = tmp_path / "ignored"
+    keep = cwd_tmp / "keep.md"
+    ignored_dir = cwd_tmp / "ignored"
     ignored_dir.mkdir()
     skip = ignored_dir / "skip.md"
     keep.write_text("ok")
     skip.write_text("nope")
-    (tmp_path / ".gitignore").write_text("ignored/\n")
-
-    monkeypatch.chdir(tmp_path)
+    (cwd_tmp / ".gitignore").write_text("ignored/\n")
 
     found = list(discover_markdown_files())
     assert found == [keep]
 
 
-def test_discover_markdown_files_skips_root_file(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_discover_markdown_files_skips_root_file(cwd_tmp: Path) -> None:
     """Skip files ignored at the repository root."""
-    keep = tmp_path / "keep.md"
-    skip = tmp_path / "skip.md"
+    keep = cwd_tmp / "keep.md"
+    skip = cwd_tmp / "skip.md"
     keep.write_text("ok")
     skip.write_text("nope")
-    (tmp_path / ".gitignore").write_text("skip.md\n")
-
-    monkeypatch.chdir(tmp_path)
+    (cwd_tmp / ".gitignore").write_text("skip.md\n")
 
     found = list(discover_markdown_files())
     assert found == [keep]
 
 
-def test_discover_markdown_files_handles_negation_and_order(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_discover_markdown_files_handles_negation_and_order(cwd_tmp: Path) -> None:
     """Support re-inclusion patterns and yield deterministically."""
-    ignored_dir = tmp_path / "ignored"
+    ignored_dir = cwd_tmp / "ignored"
     ignored_dir.mkdir()
     reincluded = ignored_dir / "keep.md"
     reincluded.write_text("keep")
     skipped = ignored_dir / "skip.md"
     skipped.write_text("skip")
-    root = tmp_path / "root.md"
+    root = cwd_tmp / "root.md"
     root.write_text("root")
-    (tmp_path / ".gitignore").write_text("ignored/\n!ignored/keep.md\n")
-
-    monkeypatch.chdir(tmp_path)
+    (cwd_tmp / ".gitignore").write_text("ignored/\n!ignored/keep.md\n")
 
     found = list(discover_markdown_files())
     assert found == [reincluded, root]
 
 
-def test_discover_markdown_files_empty_directory(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_discover_markdown_files_empty_directory(cwd_tmp: Path) -> None:
     """Return no paths when the directory has no Markdown files."""
-    (tmp_path / ".gitignore").write_text("\n")
-    monkeypatch.chdir(tmp_path)
+    (cwd_tmp / ".gitignore").write_text("\n")
 
     found = list(discover_markdown_files())
     assert found == []
 
 
-def test_discover_markdown_files_ignores_nested_gitignore(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_discover_markdown_files_ignores_nested_gitignore(cwd_tmp: Path) -> None:
     """Nested ``.gitignore`` files are ignored."""
-    sub = tmp_path / "sub"
+    sub = cwd_tmp / "sub"
     sub.mkdir()
     keep = sub / "keep.md"
     skip = sub / "skip.md"
@@ -89,25 +79,19 @@ def test_discover_markdown_files_ignores_nested_gitignore(
     skip.write_text("nope")
     (sub / ".gitignore").write_text("skip.md\n")
 
-    monkeypatch.chdir(tmp_path)
-
     found = list(discover_markdown_files())
     assert set(found) == {keep, skip}
 
 
-def test_collect_markdown_files_respects_gitignore(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_collect_markdown_files_respects_gitignore(cwd_tmp: Path) -> None:
     """Skip ignored paths when expanding explicit directories."""
-    keep = tmp_path / "keep.md"
-    ignored_dir = tmp_path / "ignored"
+    keep = cwd_tmp / "keep.md"
+    ignored_dir = cwd_tmp / "ignored"
     ignored_dir.mkdir()
     skip = ignored_dir / "skip.md"
     keep.write_text("ok")
     skip.write_text("nope")
-    (tmp_path / ".gitignore").write_text("ignored/\n")
+    (cwd_tmp / ".gitignore").write_text("ignored/\n")
 
-    monkeypatch.chdir(tmp_path)
-
-    found = list(collect_markdown_files([tmp_path]))
+    found = list(collect_markdown_files([cwd_tmp]))
     assert found == [keep]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Validate Mermaid diagrams in Markdown files"
 readme = "README.md"
 requires-python = ">=3.11"
+dependencies = ["pathspec"]
 license = { text = "ISC" }
 authors = [{ name = "Payton McIntosh", email = "pmcintosh@df12.net" }]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Validate Mermaid diagrams in Markdown files"
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = ["pathspec"]
+dependencies = ["pathspec>=0.12.1,<1.0"]
 license = { text = "ISC" }
 authors = [{ name = "Payton McIntosh", email = "pmcintosh@df12.net" }]
 classifiers = [

--- a/tests/integration/test_gitignore_paths.py
+++ b/tests/integration/test_gitignore_paths.py
@@ -1,0 +1,33 @@
+"""Integration tests for .gitignore handling with explicit paths."""
+
+from __future__ import annotations
+
+import typing as typ
+from pathlib import Path
+
+import pytest
+
+from nixie.cli import main
+
+if typ.TYPE_CHECKING:
+    from unittest.mock import AsyncMock
+
+
+@pytest.mark.asyncio
+async def test_main_skips_ignored_entries_when_paths_given(
+    tmp_path: Path, stub_render: AsyncMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Respect ``.gitignore`` when explicit directory paths are supplied."""
+    keep = tmp_path / "keep.md"
+    ignored = tmp_path / "ignored"
+    ignored.mkdir()
+    (ignored / "skip.md").write_text("ignored")
+    keep.write_text("```mermaid\nA-->B\n```")
+    (tmp_path / ".gitignore").write_text("ignored/\n")
+
+    monkeypatch.chdir(tmp_path)
+
+    exit_code = await main([Path()], 2)
+    assert exit_code == 0
+    assert stub_render.await_count == 1
+    assert stub_render.await_args_list[0].args[3] == keep.relative_to(tmp_path)

--- a/tests/integration/test_gitignore_paths.py
+++ b/tests/integration/test_gitignore_paths.py
@@ -32,3 +32,23 @@ async def test_main_skips_ignored_entries_when_paths_given(
     assert stub_render.await_count == 1
     rendered_path = stub_render.await_args_list[0].args[3]  # path argument to renderer
     assert rendered_path == keep.relative_to(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_main_skips_root_ignored_file_when_paths_given(
+    tmp_path: Path, stub_render: AsyncMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Respect root-level ignore patterns for explicit paths."""
+    keep = tmp_path / "keep.md"
+    skip = tmp_path / "skip.md"
+    keep.write_text("```mermaid\nA-->B\n```")
+    skip.write_text("ignored")
+    (tmp_path / ".gitignore").write_text("skip.md\n")
+
+    monkeypatch.chdir(tmp_path)
+
+    exit_code = await main([Path(".")], 2)  # noqa: PTH201 - explicit current directory
+    assert exit_code == 0
+    assert stub_render.await_count == 1
+    rendered_path = stub_render.await_args_list[0].args[3]  # path argument to renderer
+    assert rendered_path == keep.relative_to(tmp_path)

--- a/tests/integration/test_gitignore_paths.py
+++ b/tests/integration/test_gitignore_paths.py
@@ -27,7 +27,8 @@ async def test_main_skips_ignored_entries_when_paths_given(
 
     monkeypatch.chdir(tmp_path)
 
-    exit_code = await main([Path()], 2)
+    exit_code = await main([Path(".")], 2)  # noqa: PTH201 - explicit current directory
     assert exit_code == 0
     assert stub_render.await_count == 1
-    assert stub_render.await_args_list[0].args[3] == keep.relative_to(tmp_path)
+    rendered_path = stub_render.await_args_list[0].args[3]  # path argument to renderer
+    assert rendered_path == keep.relative_to(tmp_path)

--- a/tests/integration/test_no_args.py
+++ b/tests/integration/test_no_args.py
@@ -46,13 +46,16 @@ def test_cli_scans_cwd_when_no_args(
 
 
 def test_cli_handles_empty_directory(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     """Exit successfully when no Markdown files are present."""
-    captured: list[Path] = []
+    called = False
 
     async def fake_main(paths: cabc.Iterable[Path], _concurrency: int) -> int:
-        captured.extend(paths)
+        nonlocal called
+        called = True
         return 0
 
     monkeypatch.setattr(cli_module, "main", fake_main)
@@ -66,6 +69,7 @@ def test_cli_handles_empty_directory(
     assert exc.code == 0, (
         "cli() must exit with code 0 when no Markdown files are present"
     )
-    assert captured == [], (
-        "cli() must pass no paths to main() when no Markdown files are found"
-    )
+    assert not called, "cli() must not invoke main() when no Markdown files exist"
+    captured = capsys.readouterr()
+    assert captured.err.strip() == "No Markdown files found."
+    assert captured.out == ""

--- a/tests/integration/test_no_args.py
+++ b/tests/integration/test_no_args.py
@@ -39,5 +39,33 @@ def test_cli_scans_cwd_when_no_args(
         cli_module.cli()
 
     exc = typ.cast("SystemExit", excinfo.value)
-    assert exc.code == 0
-    assert captured == [keep]
+    assert exc.code == 0, "cli() must exit with code 0 when run without arguments"
+    assert captured == [keep], (
+        "cli() must pass exactly the discovered Markdown file(s) to main()"
+    )
+
+
+def test_cli_handles_empty_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Exit successfully when no Markdown files are present."""
+    captured: list[Path] = []
+
+    async def fake_main(paths: cabc.Iterable[Path], _concurrency: int) -> int:
+        captured.extend(paths)
+        return 0
+
+    monkeypatch.setattr(cli_module, "main", fake_main)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["nixie"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli_module.cli()
+
+    exc = typ.cast("SystemExit", excinfo.value)
+    assert exc.code == 0, (
+        "cli() must exit with code 0 when no Markdown files are present"
+    )
+    assert captured == [], (
+        "cli() must pass no paths to main() when no Markdown files are found"
+    )

--- a/tests/integration/test_no_args.py
+++ b/tests/integration/test_no_args.py
@@ -38,6 +38,6 @@ def test_cli_scans_cwd_when_no_args(
     with pytest.raises(SystemExit) as excinfo:
         cli_module.cli()
 
-    exc = typ.cast(SystemExit, excinfo.value)
+    exc = typ.cast("SystemExit", excinfo.value)
     assert exc.code == 0
     assert captured == [keep]

--- a/tests/integration/test_no_args.py
+++ b/tests/integration/test_no_args.py
@@ -1,0 +1,43 @@
+"""Integration tests for running ``nixie`` without arguments."""
+
+from __future__ import annotations
+
+import sys
+import typing as typ
+
+import pytest
+
+from nixie import cli as cli_module
+
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+    from pathlib import Path
+
+
+def test_cli_scans_cwd_when_no_args(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Discover Markdown files in CWD when no paths are supplied."""
+    keep = tmp_path / "keep.md"
+    ignored = tmp_path / "ignored"
+    ignored.mkdir()
+    (ignored / "skip.md").write_text("ignored")
+    keep.write_text("ok")
+    (tmp_path / ".gitignore").write_text("ignored/\n")
+
+    captured: list[Path] = []
+
+    async def fake_main(paths: cabc.Iterable[Path], _concurrency: int) -> int:
+        captured.extend(paths)
+        return 0
+
+    monkeypatch.setattr(cli_module, "main", fake_main)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["nixie"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli_module.cli()
+
+    exc = typ.cast(SystemExit, excinfo.value)
+    assert exc.code == 0
+    assert captured == [keep]

--- a/uv.lock
+++ b/uv.lock
@@ -24,6 +24,9 @@ wheels = [
 name = "nixie"
 version = "0.1.0"
 source = { editable = "." }
+dependencies = [
+    { name = "pathspec" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -34,6 +37,7 @@ dev = [
 ]
 
 [package.metadata]
+requires-dist = [{ name = "pathspec" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -59,6 +63,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -37,7 +37,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pathspec" }]
+requires-dist = [{ name = "pathspec", specifier = ">=0.12.1,<1.0" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- default nixie to discover Markdown files when no paths are supplied
- document implicit Markdown discovery and ignore patterns
- add pathspec dependency and supporting tests

## Testing
- `make check-fmt`
- `make lint`
- `make typecheck`
- `make test`
- `make markdownlint` *(fails: reference link definitions missing in .rules/ and other files)*
- `/root/.bun/bin/markdownlint-cli2 README.md docs/CHANGELOG.md`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68a3be0640988322b06cb7fadfad778e

## Summary by Sourcery

Enable nixie to scan the working directory for Markdown files by default when no paths are specified, honoring .gitignore entries.

New Features:
- Automatically discover and validate all Markdown files in the current directory when no paths are provided, respecting .gitignore patterns
- Add pathspec dependency for ignore-pattern handling

Enhancements:
- Allow zero or more positional paths in the CLI and fallback to implicit file discovery when none are supplied
- Refactor argument parsing and CLI entrypoint to integrate the new discovery behavior

Documentation:
- Document implicit Markdown file discovery and .gitignore support in README and CHANGELOG

Tests:
- Add unit tests for discover_markdown_files and integration tests for CLI behavior with no arguments