### PR TITLE
Add option to disable Puppeteer sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ uv sync --include dev
 ## Usage
 
 ```bash
-nixie [--concurrency N] [--verbose] [FILE ...]
+nixie [--concurrency N] [--verbose] [--no-sandbox] [FILE ...]
 ```
 
 `--concurrency` controls how many diagrams are processed in parallel (defaults
@@ -56,7 +56,10 @@ Only the `.gitignore` file in the working directory is used; nested
 `.gitignore` files are ignored.
 
 `--verbose` sets the `nixie.cli` logger to `INFO`, logging the exact
-`mermaid-cli` command for each diagram.
+`mermaid-cli` command for each diagram. By default, nixie launches Puppeteer
+with `--disable-setuid-sandbox`, `--disable-gpu`, and
+`--disable-dev-shm-usage` for reliable headless operation. Use `--no-sandbox`
+to also pass `--no-sandbox` to Chromium.
 
 When multiple files are provided, nixie prints markers that show where the
 output for each file starts and ends:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,13 +6,12 @@
    `mermaid-cli` commands. The `render_block(verbose=...)` parameter is
    deprecated and has no effect; configure the `nixie.cli` logger directly
    instead.
-- When run as root, nixie now invokes `mmdc` with a Puppeteer configuration
-  that disables the sandbox (`--no-sandbox` and `--disable-setuid-sandbox`).
 - Directory traversal honours `.gitignore` patterns in the working directory only.
   When run without arguments, nixie scans the current directory for Markdown files
   using those ignore rules (nested `.gitignore` files are ignored).
 - `nixie` searches common install locations for `mmdc` before falling back to
   `bun` or `npx`.
 - `nixie` always passes `--disable-setuid-sandbox`, `--disable-gpu`, and
-   `--disable-dev-shm-usage` to Puppeteer and exposes a `--no-sandbox` flag to
-   disable Chromium's sandbox when needed.
+  `--disable-dev-shm-usage` to Puppeteer. A new `--no-sandbox` flag disables
+  Chromium's sandbox when needed and is applied automatically when running as
+  root.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,3 +13,6 @@
   using those ignore rules (nested `.gitignore` files are ignored).
 - `nixie` searches common install locations for `mmdc` before falling back to
   `bun` or `npx`.
+- `nixie` always passes `--disable-setuid-sandbox`, `--disable-gpu`, and
+   `--disable-dev-shm-usage` to Puppeteer and exposes a `--no-sandbox` flag to
+   disable Chromium's sandbox when needed.

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -44,6 +44,12 @@ BLOCK_RE = re.compile(
 
 ALLOWED_EXECUTABLES: typ.Final[frozenset[str]] = frozenset({"mmdc", "bun", "npx"})
 
+DEFAULT_PUPPETEER_ARGS: typ.Final[tuple[str, ...]] = (
+    "--disable-setuid-sandbox",
+    "--disable-gpu",
+    "--disable-dev-shm-usage",
+)
+
 
 class UnexpectedExecutableError(ValueError):
     """Raised when an executable outside the allowed set is requested."""
@@ -129,19 +135,14 @@ def create_puppeteer_config(
     *,
     force_no_sandbox: bool = False,
 ) -> typ.Generator[Path, None, None]:
-    """Yield a Puppeteer config path and remove it on exit.
+    """Yield a temporary Puppeteer config ``Path`` and remove it on exit.
 
-    ``mmdc`` relies on Chromium, which benefits from several default flags to
-    operate reliably in diverse environments. We always include flags that
-    disable setuid sandboxing, GPU usage and shared memory consumption. The
-    ``--no-sandbox`` flag is added automatically when running as ``root`` or
-    when ``force_no_sandbox`` is ``True``.
+    ``mmdc`` relies on Chromium, which operates more reliably with a handful of
+    default flags. We always include :data:`DEFAULT_PUPPETEER_ARGS` and append
+    ``--no-sandbox`` when running as ``root`` or when
+    ``force_no_sandbox`` is ``True``.
     """
-    args = [
-        "--disable-setuid-sandbox",
-        "--disable-gpu",
-        "--disable-dev-shm-usage",
-    ]
+    args = list(DEFAULT_PUPPETEER_ARGS)
     geteuid = getattr(os, "geteuid", lambda: 1)
     if force_no_sandbox or geteuid() == 0:
         args.append("--no-sandbox")
@@ -479,7 +480,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--no-sandbox",
         action="store_true",
-        help="Force Puppeteer to disable its sandbox",
+        help=(
+            "Force Puppeteer to disable its sandbox (useful in Docker or when "
+            "running as root)"
+        ),
     )
     return parser.parse_args()
 

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -125,21 +125,28 @@ def collect_markdown_files(paths: cabc.Iterable[Path]) -> cabc.Generator[Path]:
 
 
 @contextmanager
-def create_puppeteer_config() -> typ.Generator[Path | None, None, None]:
+def create_puppeteer_config(
+    *,
+    force_no_sandbox: bool = False,
+) -> typ.Generator[Path, None, None]:
     """Yield a Puppeteer config path and remove it on exit.
 
-    When running as the root user, ``mmdc`` must be invoked with sandboxing
-    disabled. We accomplish this by writing a temporary Puppeteer configuration
-    file that passes ``--no-sandbox`` and ``--disable-setuid-sandbox``. If the
-    current process is not running as root, ``None`` is yielded so callers can
-    omit the extra CLI flag entirely.
+    ``mmdc`` relies on Chromium, which benefits from several default flags to
+    operate reliably in diverse environments. We always include flags that
+    disable setuid sandboxing, GPU usage and shared memory consumption. The
+    ``--no-sandbox`` flag is added automatically when running as ``root`` or
+    when ``force_no_sandbox`` is ``True``.
     """
+    args = [
+        "--disable-setuid-sandbox",
+        "--disable-gpu",
+        "--disable-dev-shm-usage",
+    ]
     geteuid = getattr(os, "geteuid", lambda: 1)
-    if geteuid() != 0:
-        yield None
-        return
+    if force_no_sandbox or geteuid() == 0:
+        args.append("--no-sandbox")
     with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
-        json.dump({"args": ["--no-sandbox", "--disable-setuid-sandbox"]}, fh)
+        json.dump({"args": args}, fh)
         fh.flush()
         name = fh.name
     path = Path(name)
@@ -411,10 +418,15 @@ async def check_file(
     return all(result is True for result in results)
 
 
-async def main(paths: cabc.Iterable[Path], max_concurrent: int) -> int:
+async def main(
+    paths: cabc.Iterable[Path],
+    max_concurrent: int,
+    *,
+    no_sandbox: bool = False,
+) -> int:
     """Run the CLI entry point."""
     semaphore = asyncio.Semaphore(max_concurrent)
-    with create_puppeteer_config() as cfg_path:
+    with create_puppeteer_config(force_no_sandbox=no_sandbox) as cfg_path:
         all_success = True
         for path in collect_markdown_files(paths):
             print(f"==> {path}")
@@ -464,6 +476,11 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Log mermaid-cli commands for each diagram",
     )
+    parser.add_argument(
+        "--no-sandbox",
+        action="store_true",
+        help="Force Puppeteer to disable its sandbox",
+    )
     return parser.parse_args()
 
 
@@ -484,7 +501,7 @@ def cli() -> None:
         if not paths:
             print("No Markdown files found.", file=sys.stderr)
             sys.exit(0)
-    sys.exit(asyncio.run(main(paths, parsed.concurrency)))
+    sys.exit(asyncio.run(main(paths, parsed.concurrency, no_sandbox=parsed.no_sandbox)))
 
 
 if __name__ == "__main__":

--- a/nixie/unittests/test_puppeteer_config.py
+++ b/nixie/unittests/test_puppeteer_config.py
@@ -15,20 +15,48 @@ if typ.TYPE_CHECKING:
 
 
 def test_create_puppeteer_config_as_root(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Include sandbox-disabling args when running as root."""
+    """Include sandbox args automatically for the root user."""
     monkeypatch.setattr(os, "geteuid", lambda: 0)
     path: Path | None = None
     with create_puppeteer_config() as cfg:
-        assert cfg is not None
         path = cfg
         data = json.loads(cfg.read_text())
-        assert data["args"] == ["--no-sandbox", "--disable-setuid-sandbox"]
+        assert data["args"] == [
+            "--disable-setuid-sandbox",
+            "--disable-gpu",
+            "--disable-dev-shm-usage",
+            "--no-sandbox",
+        ]
     assert path is not None
     assert not path.exists()
 
 
 def test_create_puppeteer_config_non_root(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Omit the config file when not running as root."""
+    """Provide default flags even when not running as root."""
     monkeypatch.setattr(os, "geteuid", lambda: 1)
+    path: Path | None = None
     with create_puppeteer_config() as cfg:
-        assert cfg is None
+        path = cfg
+        data = json.loads(cfg.read_text())
+        assert data["args"] == [
+            "--disable-setuid-sandbox",
+            "--disable-gpu",
+            "--disable-dev-shm-usage",
+        ]
+    assert path is not None
+    assert not path.exists()
+
+
+def test_create_puppeteer_config_force_no_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Allow users to explicitly disable the sandbox."""
+    monkeypatch.setattr(os, "geteuid", lambda: 1)
+    with create_puppeteer_config(force_no_sandbox=True) as cfg:
+        data = json.loads(cfg.read_text())
+        assert data["args"] == [
+            "--disable-setuid-sandbox",
+            "--disable-gpu",
+            "--disable-dev-shm-usage",
+            "--no-sandbox",
+        ]

--- a/nixie/unittests/test_puppeteer_config.py
+++ b/nixie/unittests/test_puppeteer_config.py
@@ -6,57 +6,71 @@ import json
 import os
 import typing as typ
 
-from nixie.cli import create_puppeteer_config
+import pytest
+
+from nixie.cli import DEFAULT_PUPPETEER_ARGS, create_puppeteer_config
 
 if typ.TYPE_CHECKING:
     from pathlib import Path
 
-    import pytest
+
+class Scenario(typ.NamedTuple):
+    """Parameters for :func:`create_puppeteer_config` scenarios."""
+
+    euid: int
+    force_no_sandbox: bool
+    expected: list[str]
 
 
-def test_create_puppeteer_config_as_root(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Include sandbox args automatically for the root user."""
-    monkeypatch.setattr(os, "geteuid", lambda: 0)
-    path: Path | None = None
-    with create_puppeteer_config() as cfg:
-        path = cfg
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        Scenario(
+            euid=0,
+            force_no_sandbox=False,
+            expected=[*DEFAULT_PUPPETEER_ARGS, "--no-sandbox"],
+        ),
+        Scenario(
+            euid=1,
+            force_no_sandbox=False,
+            expected=list(DEFAULT_PUPPETEER_ARGS),
+        ),
+        Scenario(
+            euid=1,
+            force_no_sandbox=True,
+            expected=[*DEFAULT_PUPPETEER_ARGS, "--no-sandbox"],
+        ),
+    ],
+)
+def test_create_puppeteer_config_args(
+    monkeypatch: pytest.MonkeyPatch, scenario: Scenario
+) -> None:
+    """Generate the expected flag sets under different scenarios."""
+    monkeypatch.setattr(os, "geteuid", lambda: scenario.euid, raising=False)
+    with create_puppeteer_config(force_no_sandbox=scenario.force_no_sandbox) as cfg:
         data = json.loads(cfg.read_text())
-        assert data["args"] == [
-            "--disable-setuid-sandbox",
-            "--disable-gpu",
-            "--disable-dev-shm-usage",
-            "--no-sandbox",
-        ]
-    assert path is not None
-    assert not path.exists()
-
-
-def test_create_puppeteer_config_non_root(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Provide default flags even when not running as root."""
-    monkeypatch.setattr(os, "geteuid", lambda: 1)
-    path: Path | None = None
-    with create_puppeteer_config() as cfg:
+        assert set(data["args"]) == set(scenario.expected), (
+            "Puppeteer args should match the expected set",
+        )
         path = cfg
-        data = json.loads(cfg.read_text())
-        assert data["args"] == [
-            "--disable-setuid-sandbox",
-            "--disable-gpu",
-            "--disable-dev-shm-usage",
-        ]
-    assert path is not None
-    assert not path.exists()
+    assert not path.exists(), "Temp config file should be removed on exit"
 
 
-def test_create_puppeteer_config_force_no_sandbox(
+def test_create_puppeteer_config_cleanup_on_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Allow users to explicitly disable the sandbox."""
-    monkeypatch.setattr(os, "geteuid", lambda: 1)
-    with create_puppeteer_config(force_no_sandbox=True) as cfg:
-        data = json.loads(cfg.read_text())
-        assert data["args"] == [
-            "--disable-setuid-sandbox",
-            "--disable-gpu",
-            "--disable-dev-shm-usage",
-            "--no-sandbox",
-        ]
+    """Clean up the config file when the context exits with an error."""
+    monkeypatch.setattr(os, "geteuid", lambda: 1, raising=False)
+    path: Path | None = None
+
+    def boom() -> None:
+        nonlocal path
+        with create_puppeteer_config() as cfg:
+            path = cfg
+            raise RuntimeError
+
+    with pytest.raises(RuntimeError):
+        boom()
+
+    assert path is not None, "Context manager should yield a path"
+    assert not path.exists(), "Temp config file should be removed on error"

--- a/nixie/unittests/test_verbose.py
+++ b/nixie/unittests/test_verbose.py
@@ -22,6 +22,14 @@ def test_parse_args_verbose(monkeypatch: pytest.MonkeyPatch) -> None:
     assert parsed.paths == [Path("file.md")]
 
 
+def test_parse_args_no_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Parse the ``--no-sandbox`` flag into the argument namespace."""
+    monkeypatch.setattr(sys, "argv", ["nixie", "--no-sandbox", "file.md"])
+    parsed = parse_args()
+    assert parsed.no_sandbox is True
+    assert parsed.paths == [Path("file.md")]
+
+
 @pytest.mark.asyncio
 async def test_render_block_emits_command(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integration/test_no_args.py
+++ b/tests/integration/test_no_args.py
@@ -83,3 +83,35 @@ def test_cli_handles_empty_directory(
     captured = capsys.readouterr()
     assert captured.err.strip() == "No Markdown files found."
     assert captured.out == ""
+
+
+def test_cli_accepts_no_sandbox_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pass ``--no-sandbox`` through to :func:`main`."""
+    (tmp_path / "file.md").write_text("ok")
+
+    received_no_sandbox = False
+
+    async def fake_main(
+        paths: cabc.Iterable[Path],
+        _concurrency: int,
+        *,
+        no_sandbox: bool = False,
+    ) -> int:
+        nonlocal received_no_sandbox
+        received_no_sandbox = no_sandbox
+        return 0
+
+    monkeypatch.setattr(cli_module, "main", fake_main)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["nixie", "--no-sandbox"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli_module.cli()
+
+    exc = typ.cast("SystemExit", excinfo.value)
+    assert exc.code == 0, "cli() must exit with code 0 when --no-sandbox is set"
+    assert received_no_sandbox is True, (
+        "cli() must pass no_sandbox=True to main() when --no-sandbox is used"
+    )

--- a/tests/integration/test_no_args.py
+++ b/tests/integration/test_no_args.py
@@ -27,7 +27,12 @@ def test_cli_scans_cwd_when_no_args(
 
     captured: list[Path] = []
 
-    async def fake_main(paths: cabc.Iterable[Path], _concurrency: int) -> int:
+    async def fake_main(
+        paths: cabc.Iterable[Path],
+        _concurrency: int,
+        *,
+        no_sandbox: bool = False,
+    ) -> int:
         captured.extend(paths)
         return 0
 
@@ -53,7 +58,12 @@ def test_cli_handles_empty_directory(
     """Exit successfully when no Markdown files are present."""
     called = False
 
-    async def fake_main(paths: cabc.Iterable[Path], _concurrency: int) -> int:
+    async def fake_main(
+        paths: cabc.Iterable[Path],
+        _concurrency: int,
+        *,
+        no_sandbox: bool = False,
+    ) -> int:
         nonlocal called
         called = True
         return 0


### PR DESCRIPTION
## Summary
- add `--no-sandbox` CLI flag and always supply stable Puppeteer flags
- document new sandbox options and defaults
- cover sandbox behaviour with unit and integration tests

## Testing
- `make check-fmt`
- `make lint`
- `make typecheck`
- `make test`
- `make markdownlint` *(fails: missing reference definitions in .rules/ files)*
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68a50e685db88322b4440ffaee4f4b25

## Summary by Sourcery

Introduce a --no-sandbox option for Puppeteer and standardize default Chromium flags to improve reliability, with corresponding code refactoring, tests, and documentation updates

New Features:
- Add --no-sandbox CLI flag to force Puppeteer’s sandbox to be disabled

Enhancements:
- Always generate a Puppeteer config file with default flags (--disable-setuid-sandbox, --disable-gpu, --disable-dev-shm-usage) and conditionally include --no-sandbox
- Refactor create_puppeteer_config to accept a force_no_sandbox parameter and always yield a config path

Documentation:
- Update README and CHANGELOG to document default Puppeteer flags and the --no-sandbox option

Tests:
- Add unit tests for create_puppeteer_config covering root, non-root, and forced no-sandbox scenarios
- Update integration tests to handle the new no_sandbox argument in main()
- Add a test for parsing the --no-sandbox flag