### PR TITLE
Print celebratory message on validation success

### DIFF
--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -32,6 +32,7 @@ import typing as typ
 import warnings
 from contextlib import contextmanager, suppress
 from pathlib import Path
+from typing import Final  # noqa: ICN003
 
 try:
     import pathspec  # type: ignore[unused-ignore]
@@ -93,6 +94,8 @@ DEFAULT_PUPPETEER_ARGS: typ.Final[tuple[str, ...]] = (
     "--disable-gpu",
     "--disable-dev-shm-usage",
 )
+
+SUCCESS_BANNER: Final[str] = "🧜‍♀️✨ All diagrams validated successfully!"
 
 
 class UnexpectedExecutableError(ValueError):
@@ -532,7 +535,7 @@ async def main(paths: cabc.Iterable[Path], *, no_sandbox: bool = False) -> int:
                 all_success = False
             print(f"<== {path}")
         if all_success:
-            print("🧜‍♀️✨ All diagrams validated successfully!")
+            print(SUCCESS_BANNER, flush=True)
         return 0 if all_success else 1
 
 

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -531,6 +531,8 @@ async def main(paths: cabc.Iterable[Path], *, no_sandbox: bool = False) -> int:
             if not success:
                 all_success = False
             print(f"<== {path}")
+        if all_success:
+            print("🧜‍♀️✨ All diagrams validated successfully!")
         return 0 if all_success else 1
 
 

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -95,8 +95,7 @@ DEFAULT_PUPPETEER_ARGS: typ.Final[tuple[str, ...]] = (
     "--disable-dev-shm-usage",
 )
 
-SUCCESS_BANNER: Final[str] = "🧜‍♀️✨ All diagrams validated successfully!"
-
+SUCCESS_BANNER: typ.Final[str] = "🧜‍♀️✨ All diagrams validated successfully!"
 
 class UnexpectedExecutableError(ValueError):
     """Raised when an executable outside the allowed set is requested."""

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -96,6 +96,7 @@ DEFAULT_PUPPETEER_ARGS: typ.Final[tuple[str, ...]] = (
 
 SUCCESS_BANNER: typ.Final[str] = "🧜‍♀️✨ All diagrams validated successfully!"
 
+
 class UnexpectedExecutableError(ValueError):
     """Raised when an executable outside the allowed set is requested."""
 

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -32,7 +32,6 @@ import typing as typ
 import warnings
 from contextlib import contextmanager, suppress
 from pathlib import Path
-from typing import Final  # noqa: ICN003
 
 try:
     import pathspec  # type: ignore[unused-ignore]

--- a/tests/integration/test_cli_behavior.py
+++ b/tests/integration/test_cli_behavior.py
@@ -99,6 +99,12 @@ async def test_cli_behavior(
     expected = {(Path(p), i) for p, i in expected_calls}
     assert actual == expected
 
+    message = "🧜‍♀️✨ All diagrams validated successfully!"
+    if expected_exit == 0:
+        assert message in captured.out
+    else:
+        assert message not in captured.out
+
 
 @pytest.mark.asyncio
 async def test_cli_marks_file_boundaries(

--- a/tests/integration/test_cli_behavior.py
+++ b/tests/integration/test_cli_behavior.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from nixie.cli import UNKNOWN_SCHEMA, main
+from nixie.cli import SUCCESS_BANNER, UNKNOWN_SCHEMA, main
 
 
 class SimulatedProcessingError(ValueError):
@@ -99,11 +99,10 @@ async def test_cli_behavior(
     expected = {(Path(p), i) for p, i in expected_calls}
     assert actual == expected
 
-    message = "🧜‍♀️✨ All diagrams validated successfully!"
     if expected_exit == 0:
-        assert message in captured.out
+        assert captured.out.count(SUCCESS_BANNER) == 1
     else:
-        assert message not in captured.out
+        assert captured.out.count(SUCCESS_BANNER) == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- print a celebratory message when all diagrams validate successfully
- add integration test coverage for the success message

## Testing
- `make check-fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b1bfaac39c8322b4500f156e3c8ba3

## Summary by Sourcery

Print a festive success message after all diagrams validate and add an integration test to ensure it only shows on success

New Features:
- Print a celebratory message when all diagrams validate successfully

Tests:
- Add integration test to verify celebratory message appears only on successful validation