### PR TITLE
Allow Windows mmdc executable

### DIFF
--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -87,6 +87,7 @@ BLOCK_RE = re.compile(
 )
 
 ALLOWED_EXECUTABLES: typ.Final[frozenset[str]] = frozenset({"mmdc", "bun", "npx"})
+WINDOWS_EXECUTABLE_SUFFIXES: typ.Final[tuple[str, ...]] = (".exe", ".cmd", ".bat")
 
 DEFAULT_PUPPETEER_ARGS: typ.Final[tuple[str, ...]] = (
     "--disable-setuid-sandbox",
@@ -336,14 +337,33 @@ async def wait_for_proc(
     return success, stderr
 
 
+def _normalize_executable_name(executable: str) -> str:
+    """Return a normalized name for ``executable`` suitable for allow-listing."""
+    raw = executable.rsplit("/", 1)[-1]
+    raw = raw.rsplit("\\", 1)[-1]
+    lowered = raw.lower()
+    for suffix in WINDOWS_EXECUTABLE_SUFFIXES:
+        if lowered.endswith(suffix):
+            return lowered[: -len(suffix)]
+    return lowered
+
+
+def _is_allowed_executable(executable: str) -> bool:
+    """Return ``True`` when ``executable`` is permitted to run mermaid-cli."""
+    if not executable:
+        return False
+    normalized = _normalize_executable_name(executable)
+    return normalized in ALLOWED_EXECUTABLES
+
+
 async def _run_mermaid_cli(
     cmd: list[str],
     path: Path,
     idx: int,
     timeout: float,
 ) -> tuple[bool, bytes]:
-    exe = Path(cmd[0]).name if cmd else ""
-    if exe not in ALLOWED_EXECUTABLES:
+    executable = cmd[0] if cmd else ""
+    if not _is_allowed_executable(executable):
         raise UnexpectedExecutableError(cmd[0] if cmd else "")
 
     # nosemgrep: python.lang.security.audit.dangerous-asyncio-create-exec-audit

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -341,15 +341,18 @@ def _normalize_executable_name(executable: str) -> str:
     """Return a normalized name for ``executable`` suitable for allow-listing."""
     if not executable:
         return ""
-    # ``Path`` handles POSIX separators while ``PureWindowsPath`` copes with
-    # Windows-style ``\`` separators. Prefer the Windows interpretation when the
-    # input contains backslashes so shims like ``mmdc.EXE`` normalise reliably on
-    # Unix hosts running the tests.
-    path = PureWindowsPath(executable) if "\\" in executable else Path(executable)
-    suffix = path.suffix.lower()
+    # ``PureWindowsPath`` gracefully handles both POSIX and Windows style
+    # separators without requiring platform checks. Always interpret the input
+    # as a Windows path so that raw ``C:\\...`` strings normalise identically on
+    # Linux hosts.
+    cleaned = executable.strip()
+    if not cleaned:
+        return ""
+    path = PureWindowsPath(cleaned)
     name = path.name.lower()
-    if suffix in WINDOWS_EXECUTABLE_SUFFIXES:
-        return path.stem.lower()
+    for suffix in WINDOWS_EXECUTABLE_SUFFIXES:
+        if name.endswith(suffix):
+            return path.stem.lower()
     return name
 
 

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -31,7 +31,7 @@ import tempfile
 import typing as typ
 import warnings
 from contextlib import contextmanager, suppress
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 try:
     import pathspec  # type: ignore[unused-ignore]
@@ -339,13 +339,18 @@ async def wait_for_proc(
 
 def _normalize_executable_name(executable: str) -> str:
     """Return a normalized name for ``executable`` suitable for allow-listing."""
-    raw = executable.rsplit("/", 1)[-1]
-    raw = raw.rsplit("\\", 1)[-1]
-    lowered = raw.lower()
-    for suffix in WINDOWS_EXECUTABLE_SUFFIXES:
-        if lowered.endswith(suffix):
-            return lowered[: -len(suffix)]
-    return lowered
+    if not executable:
+        return ""
+    # ``Path`` handles POSIX separators while ``PureWindowsPath`` copes with
+    # Windows-style ``\`` separators. Prefer the Windows interpretation when the
+    # input contains backslashes so shims like ``mmdc.EXE`` normalise reliably on
+    # Unix hosts running the tests.
+    path = PureWindowsPath(executable) if "\\" in executable else Path(executable)
+    suffix = path.suffix.lower()
+    name = path.name.lower()
+    if suffix in WINDOWS_EXECUTABLE_SUFFIXES:
+        return path.stem.lower()
+    return name
 
 
 def _is_allowed_executable(executable: str) -> bool:

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -369,7 +369,7 @@ async def _run_mermaid_cli(
 ) -> tuple[bool, bytes]:
     executable = cmd[0] if cmd else ""
     if not _is_allowed_executable(executable):
-        raise UnexpectedExecutableError(cmd[0] if cmd else "")
+        raise UnexpectedExecutableError(executable)
 
     # nosemgrep: python.lang.security.audit.dangerous-asyncio-create-exec-audit
     proc = await asyncio.create_subprocess_exec(

--- a/nixie/unittests/conftest.py
+++ b/nixie/unittests/conftest.py
@@ -18,5 +18,6 @@ def fake_home_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     """
     home = tmp_path / "home"
     monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setattr("nixie.cli.Path.home", lambda: home)
     monkeypatch.chdir(tmp_path)
     return home

--- a/nixie/unittests/test_cli_executable_allowlist.py
+++ b/nixie/unittests/test_cli_executable_allowlist.py
@@ -1,0 +1,85 @@
+# ruff: noqa: D100
+
+from __future__ import annotations
+
+import pytest
+
+import nixie.cli as cli
+
+
+@pytest.mark.parametrize(
+    ("executable", "expected"),
+    [
+        ("", ""),
+        ("mmdc", "mmdc"),
+        ("bun", "bun"),
+        ("npx", "npx"),
+        ("mmdc.exe", "mmdc"),
+        ("mmdc.EXE", "mmdc"),
+        ("mmdc.cmd", "mmdc"),
+        ("mmdc.CMD", "mmdc"),
+        ("mmdc.bat", "mmdc"),
+        ("/usr/bin/mmdc", "mmdc"),
+        ("/usr/bin/mmdc.exe", "mmdc"),
+        (r"C:\\Users\\runneradmin\\.bun\\bin\\mmdc.exe", "mmdc"),
+        (r"C:\\Users\\runneradmin\\.bun\\bin\\MMDC.EXE", "mmdc"),
+        ("  C:/Program Files/mermaid-cli/mmdc.EXE  ", "mmdc"),
+        (r"C:\\Windows\\System32\\python.EXE", "python"),
+    ],
+)
+def test_normalize_executable_name_known_suffix(executable: str, expected: str) -> None:
+    """Normalise both POSIX and Windows paths with common suffixes."""
+    assert cli._normalize_executable_name(executable) == expected
+
+
+@pytest.mark.parametrize(
+    ("executable", "expected"),
+    [
+        ("python", "python"),
+        ("/usr/bin/python3", "python3"),
+        ("/usr/local/bin/python3.11", "python3.11"),
+        ("mmdc.exe.bak", "mmdc.exe.bak"),
+        (r"C:\\Users\\runneradmin\\.bun\\bin\\mmdc.exe.bak", "mmdc.exe.bak"),
+    ],
+)
+def test_normalize_executable_name_unknown_suffix(
+    executable: str, expected: str
+) -> None:
+    """Leave unexpected suffixes untouched for downstream checks."""
+    assert cli._normalize_executable_name(executable) == expected
+
+
+@pytest.mark.parametrize(
+    "executable",
+    [
+        "mmdc",
+        "mmdc.exe",
+        "mmdc.CMD",
+        "mmdc.BAT",
+        r"C:\\Users\\runneradmin\\.bun\\bin\\mmdc.EXE",
+        r"C:\\Users\\runneradmin\\.bun\\bin\\mmdc.CMD",
+        r"C:\\Users\\runneradmin\\.bun\\bin\\mmdc.BAT",
+        "bun",
+        "npx",
+        r"C:\\Program Files\\nodejs\\npx.cmd",
+    ],
+)
+def test_is_allowed_executable_accepts_allowlisted(executable: str) -> None:
+    """Allow canonical names and Windows shims for the CLI."""
+    assert cli._is_allowed_executable(executable)
+
+
+@pytest.mark.parametrize(
+    "executable",
+    [
+        "",
+        "python",
+        "python.exe",
+        r"C:\\Windows\\System32\\python.exe",
+        "mmdc.exe.bak",
+        r"C:\\Users\\runneradmin\\.bun\\bin\\mmdc.exe.bak",
+    ],
+)
+def test_is_allowed_executable_rejects_unexpected(executable: str) -> None:
+    """Reject executables outside the allow-list."""
+    assert not cli._is_allowed_executable(executable)

--- a/nixie/unittests/test_cli_executable_allowlist.py
+++ b/nixie/unittests/test_cli_executable_allowlist.py
@@ -21,10 +21,10 @@ import nixie.cli as cli
         ("mmdc.bat", "mmdc"),
         ("/usr/bin/mmdc", "mmdc"),
         ("/usr/bin/mmdc.exe", "mmdc"),
-        (r"C:\\Users\\runneradmin\\.bun\\bin\\mmdc.exe", "mmdc"),
-        (r"C:\\Users\\runneradmin\\.bun\\bin\\MMDC.EXE", "mmdc"),
+        (r"C:\Users\runneradmin\.bun\bin\mmdc.exe", "mmdc"),
+        (r"C:\Users\runneradmin\.bun\bin\MMDC.EXE", "mmdc"),
         ("  C:/Program Files/mermaid-cli/mmdc.EXE  ", "mmdc"),
-        (r"C:\\Windows\\System32\\python.EXE", "python"),
+        (r"C:\Windows\System32\python.EXE", "python"),
     ],
 )
 def test_normalize_executable_name_known_suffix(executable: str, expected: str) -> None:
@@ -39,7 +39,7 @@ def test_normalize_executable_name_known_suffix(executable: str, expected: str) 
         ("/usr/bin/python3", "python3"),
         ("/usr/local/bin/python3.11", "python3.11"),
         ("mmdc.exe.bak", "mmdc.exe.bak"),
-        (r"C:\\Users\\runneradmin\\.bun\\bin\\mmdc.exe.bak", "mmdc.exe.bak"),
+        (r"C:\Users\runneradmin\.bun\bin\mmdc.exe.bak", "mmdc.exe.bak"),
     ],
 )
 def test_normalize_executable_name_unknown_suffix(
@@ -56,12 +56,12 @@ def test_normalize_executable_name_unknown_suffix(
         "mmdc.exe",
         "mmdc.CMD",
         "mmdc.BAT",
-        r"C:\\Users\\runneradmin\\.bun\\bin\\mmdc.EXE",
-        r"C:\\Users\\runneradmin\\.bun\\bin\\mmdc.CMD",
-        r"C:\\Users\\runneradmin\\.bun\\bin\\mmdc.BAT",
+        r"C:\Users\runneradmin\.bun\bin\mmdc.EXE",
+        r"C:\Users\runneradmin\.bun\bin\mmdc.CMD",
+        r"C:\Users\runneradmin\.bun\bin\mmdc.BAT",
         "bun",
         "npx",
-        r"C:\\Program Files\\nodejs\\npx.cmd",
+        r"C:\Program Files\nodejs\npx.cmd",
     ],
 )
 def test_is_allowed_executable_accepts_allowlisted(executable: str) -> None:
@@ -75,9 +75,9 @@ def test_is_allowed_executable_accepts_allowlisted(executable: str) -> None:
         "",
         "python",
         "python.exe",
-        r"C:\\Windows\\System32\\python.exe",
+        r"C:\Windows\System32\python.exe",
         "mmdc.exe.bak",
-        r"C:\\Users\\runneradmin\\.bun\\bin\\mmdc.exe.bak",
+        r"C:\Users\runneradmin\.bun\bin\mmdc.exe.bak",
     ],
 )
 def test_is_allowed_executable_rejects_unexpected(executable: str) -> None:

--- a/nixie/unittests/test_cli_executable_allowlist.py
+++ b/nixie/unittests/test_cli_executable_allowlist.py
@@ -1,4 +1,4 @@
-# ruff: noqa: D100
+"""Unit tests for CLI executable normalisation and allow-list validation."""
 
 from __future__ import annotations
 

--- a/nixie/unittests/test_render_diagram.py
+++ b/nixie/unittests/test_render_diagram.py
@@ -12,8 +12,6 @@ import pytest
 
 from nixie.cli import (
     WINDOWS_EXECUTABLE_SUFFIXES,
-    _is_allowed_executable,
-    _normalize_executable_name,
     _render_diagram,
     _run_mermaid_cli,
     get_mmdc_cmd,
@@ -118,53 +116,6 @@ async def test_run_mermaid_cli_accepts_windows_executable(
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
     monkeypatch.setattr("nixie.cli.wait_for_proc", fake_wait_for_proc)
 
-    cmd = [rf"C:\\Users\\runneradmin\\.bun\\bin\\mmdc{suffix.upper()}", "--version"]
+    cmd = [rf"C:\Users\runneradmin\.bun\bin\mmdc{suffix.upper()}", "--version"]
     result = await _run_mermaid_cli(cmd, Path("doc.md"), 1, 30.0)
     assert result == (True, b"")
-
-
-@pytest.mark.parametrize(
-    ("executable", "expected"),
-    [
-        ("mmdc", "mmdc"),
-        ("mmdc.EXE", "mmdc"),
-        ("/usr/bin/mmdc", "mmdc"),
-        ("/usr/bin/mmdc.exe", "mmdc"),
-        ("C:/Users/runneradmin/.bun/bin/mmdc.exe", "mmdc"),
-        (r"C:\\Users\\runneradmin\\.bun\\bin\\mmdc.EXE", "mmdc"),
-        ("npx.cmd", "npx"),
-        ("BUN.BAT", "bun"),
-        ("./mmdc.sh", "mmdc.sh"),
-        ("", ""),
-    ],
-)
-def test_normalize_executable_name(executable: str, expected: str) -> None:
-    """Return consistent, lower-cased executable names across platforms."""
-    assert _normalize_executable_name(executable) == expected
-
-
-@pytest.mark.parametrize(
-    "executable",
-    [
-        "mmdc",
-        "/usr/bin/mmdc",
-        "C:/Users/runneradmin/.bun/bin/mmdc.exe",
-        r"C:\\Users\\runneradmin\\.bun\\bin\\mmdc.EXE",
-        "npx",
-        "npx.cmd",
-        "bun",
-        "BUN.BAT",
-    ],
-)
-def test_is_allowed_executable_accepts_known_names(executable: str) -> None:
-    """Allow common mermaid-cli launchers, including Windows shims."""
-    assert _is_allowed_executable(executable) is True
-
-
-@pytest.mark.parametrize(
-    "executable",
-    ["", "python", "./mmdc.sh", r"C:\\tools\\mermaid.cmdx"],
-)
-def test_is_allowed_executable_rejects_unknown_names(executable: str) -> None:
-    """Reject executables outside the allow-list."""
-    assert _is_allowed_executable(executable) is False

--- a/nixie/unittests/test_render_diagram.py
+++ b/nixie/unittests/test_render_diagram.py
@@ -88,3 +88,25 @@ async def test_run_mermaid_cli_rejects_unexpected_executable() -> None:
     cmd = ["echo", "hello"]
     with pytest.raises(ValueError, match="Unexpected executable"):
         await _run_mermaid_cli(cmd, path, 1, 30.0)
+
+
+@pytest.mark.asyncio
+async def test_run_mermaid_cli_accepts_windows_executable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Treat Windows ``.EXE`` binaries as valid executables."""
+
+    async def fake_create_subprocess_exec(*_cmd: str, **_kwargs: object) -> object:
+        return object()
+
+    async def fake_wait_for_proc(
+        _proc: object, _path: Path, _idx: int, _timeout: float
+    ) -> tuple[bool, bytes]:
+        return True, b""
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr("nixie.cli.wait_for_proc", fake_wait_for_proc)
+
+    cmd = [r"C:\\Users\\runneradmin\\.bun\\bin\\mmdc.EXE", "--version"]
+    result = await _run_mermaid_cli(cmd, Path("doc.md"), 1, 30.0)
+    assert result == (True, b"")

--- a/nixie/unittests/test_render_diagram.py
+++ b/nixie/unittests/test_render_diagram.py
@@ -89,10 +89,16 @@ async def test_render_diagram_raises_on_failure(
 
 
 @pytest.mark.asyncio
-async def test_run_mermaid_cli_rejects_unexpected_executable() -> None:
+@pytest.mark.parametrize(
+    "executable",
+    ["", "python", "./mmdc.sh", r"C:\tools\mermaid.cmdx"],
+)
+async def test_run_mermaid_cli_rejects_unexpected_executable(
+    executable: str,
+) -> None:
     """Reject executables outside the allowed set."""
     path = Path("doc.md")
-    cmd = ["echo", "hello"]
+    cmd = [executable] if executable else []
     with pytest.raises(ValueError, match="Unexpected executable"):
         await _run_mermaid_cli(cmd, path, 1, 30.0)
 

--- a/nixie/unittests/test_render_diagram.py
+++ b/nixie/unittests/test_render_diagram.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import shlex
-import shutil
 from pathlib import Path
 
 import pytest
@@ -39,9 +37,11 @@ async def test_render_diagram_writes_file_and_logs(
     ) -> tuple[bool, bytes]:
         return True, b""
 
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr(
+        "nixie.cli.asyncio.create_subprocess_exec", fake_create_subprocess_exec
+    )
     monkeypatch.setattr("nixie.cli.wait_for_proc", fake_wait_for_proc)
-    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/mmdc")
+    monkeypatch.setattr("nixie.cli.shutil.which", lambda _cmd: "/usr/bin/mmdc")
 
     with caplog.at_level(logging.INFO, logger="nixie.cli"):
         await _render_diagram(block, tmp_path, cfg_path, path, 1, 30.0)
@@ -73,9 +73,11 @@ async def test_render_diagram_raises_on_failure(
     ) -> tuple[bool, bytes]:
         return False, b"Parse error on line 1:\nfoo\n^\n"
 
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr(
+        "nixie.cli.asyncio.create_subprocess_exec", fake_create_subprocess_exec
+    )
     monkeypatch.setattr("nixie.cli.wait_for_proc", fake_wait_for_proc)
-    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/mmdc")
+    monkeypatch.setattr("nixie.cli.shutil.which", lambda _cmd: "/usr/bin/mmdc")
 
     with pytest.raises(RuntimeError) as err:
         await _render_diagram(block, tmp_path, cfg_path, path, 1, 30.0)
@@ -113,7 +115,9 @@ async def test_run_mermaid_cli_accepts_windows_executable(
     ) -> tuple[bool, bytes]:
         return True, b""
 
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr(
+        "nixie.cli.asyncio.create_subprocess_exec", fake_create_subprocess_exec
+    )
     monkeypatch.setattr("nixie.cli.wait_for_proc", fake_wait_for_proc)
 
     cmd = [rf"C:\Users\runneradmin\.bun\bin\mmdc{suffix.upper()}", "--version"]

--- a/nixie/unittests/test_render_diagram.py
+++ b/nixie/unittests/test_render_diagram.py
@@ -10,7 +10,14 @@ from pathlib import Path
 
 import pytest
 
-from nixie.cli import _render_diagram, _run_mermaid_cli, get_mmdc_cmd
+from nixie.cli import (
+    WINDOWS_EXECUTABLE_SUFFIXES,
+    _is_allowed_executable,
+    _normalize_executable_name,
+    _render_diagram,
+    _run_mermaid_cli,
+    get_mmdc_cmd,
+)
 
 
 @pytest.mark.asyncio
@@ -91,10 +98,14 @@ async def test_run_mermaid_cli_rejects_unexpected_executable() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "suffix",
+    WINDOWS_EXECUTABLE_SUFFIXES,
+)
 async def test_run_mermaid_cli_accepts_windows_executable(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, suffix: str
 ) -> None:
-    """Treat Windows ``.EXE`` binaries as valid executables."""
+    """Treat Windows executables with common suffixes as valid shims."""
 
     async def fake_create_subprocess_exec(*_cmd: str, **_kwargs: object) -> object:
         return object()
@@ -107,6 +118,53 @@ async def test_run_mermaid_cli_accepts_windows_executable(
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
     monkeypatch.setattr("nixie.cli.wait_for_proc", fake_wait_for_proc)
 
-    cmd = [r"C:\\Users\\runneradmin\\.bun\\bin\\mmdc.EXE", "--version"]
+    cmd = [rf"C:\\Users\\runneradmin\\.bun\\bin\\mmdc{suffix.upper()}", "--version"]
     result = await _run_mermaid_cli(cmd, Path("doc.md"), 1, 30.0)
     assert result == (True, b"")
+
+
+@pytest.mark.parametrize(
+    ("executable", "expected"),
+    [
+        ("mmdc", "mmdc"),
+        ("mmdc.EXE", "mmdc"),
+        ("/usr/bin/mmdc", "mmdc"),
+        ("/usr/bin/mmdc.exe", "mmdc"),
+        ("C:/Users/runneradmin/.bun/bin/mmdc.exe", "mmdc"),
+        (r"C:\\Users\\runneradmin\\.bun\\bin\\mmdc.EXE", "mmdc"),
+        ("npx.cmd", "npx"),
+        ("BUN.BAT", "bun"),
+        ("./mmdc.sh", "mmdc.sh"),
+        ("", ""),
+    ],
+)
+def test_normalize_executable_name(executable: str, expected: str) -> None:
+    """Return consistent, lower-cased executable names across platforms."""
+    assert _normalize_executable_name(executable) == expected
+
+
+@pytest.mark.parametrize(
+    "executable",
+    [
+        "mmdc",
+        "/usr/bin/mmdc",
+        "C:/Users/runneradmin/.bun/bin/mmdc.exe",
+        r"C:\\Users\\runneradmin\\.bun\\bin\\mmdc.EXE",
+        "npx",
+        "npx.cmd",
+        "bun",
+        "BUN.BAT",
+    ],
+)
+def test_is_allowed_executable_accepts_known_names(executable: str) -> None:
+    """Allow common mermaid-cli launchers, including Windows shims."""
+    assert _is_allowed_executable(executable) is True
+
+
+@pytest.mark.parametrize(
+    "executable",
+    ["", "python", "./mmdc.sh", r"C:\\tools\\mermaid.cmdx"],
+)
+def test_is_allowed_executable_rejects_unknown_names(executable: str) -> None:
+    """Reject executables outside the allow-list."""
+    assert _is_allowed_executable(executable) is False

--- a/tests/integration/test_windows_executables.py
+++ b/tests/integration/test_windows_executables.py
@@ -1,0 +1,69 @@
+"""Behavioural tests covering Windows mermaid-cli executables."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from nixie.cli import render_block
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "executable",
+    [
+        r"C:\\Users\\runneradmin\\.bun\\bin\\mmdc.EXE",
+        r"C:\\Users\\runneradmin\\.bun\\bin\\mmdc.CMD",
+        r"C:\\Users\\runneradmin\\.bun\\bin\\mmdc.BAT",
+    ],
+)
+async def test_render_block_accepts_windows_executables(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, executable: str
+) -> None:
+    """Allow Windows shims discovered via ``which`` when rendering."""
+
+    async def fake_create_subprocess_exec(*cmd: str, **_kwargs: object) -> object:
+        assert cmd[0] == executable
+        return object()
+
+    async def fake_wait_for_proc(
+        _proc: object, _path: Path, _idx: int, _timeout: float
+    ) -> tuple[bool, bytes]:
+        return True, b""
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr("nixie.cli.wait_for_proc", fake_wait_for_proc)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    def fake_which(cmd: str) -> str | None:
+        return executable if cmd == "mmdc" else None
+
+    monkeypatch.setattr("nixie.cli.shutil.which", fake_which)
+
+    result = await render_block("A-->B", tmp_path, None, Path("doc.md"), 1)
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_render_block_rejects_unexpected_executable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Surface a clear error when a non-allowlisted executable is discovered."""
+
+    async def fail_create_subprocess_exec(*_cmd: str, **_kwargs: object) -> object:
+        pytest.fail("create_subprocess_exec should not be called")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fail_create_subprocess_exec)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    def fake_which(cmd: str) -> str | None:
+        return "/usr/bin/python" if cmd == "mmdc" else None
+
+    monkeypatch.setattr("nixie.cli.shutil.which", fake_which)
+
+    result = await render_block("A-->B", tmp_path, None, Path("doc.md"), 1)
+    assert result is False

--- a/tests/integration/test_windows_executables.py
+++ b/tests/integration/test_windows_executables.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from pathlib import Path
 
 import pytest
@@ -14,9 +13,9 @@ from nixie.cli import render_block
 @pytest.mark.parametrize(
     "executable",
     [
-        r"C:\\Users\\runneradmin\\.bun\\bin\\mmdc.EXE",
-        r"C:\\Users\\runneradmin\\.bun\\bin\\mmdc.CMD",
-        r"C:\\Users\\runneradmin\\.bun\\bin\\mmdc.BAT",
+        r"C:\Users\runneradmin\.bun\bin\mmdc.EXE",
+        r"C:\Users\runneradmin\.bun\bin\mmdc.CMD",
+        r"C:\Users\runneradmin\.bun\bin\mmdc.BAT",
     ],
 )
 async def test_render_block_accepts_windows_executables(
@@ -33,9 +32,11 @@ async def test_render_block_accepts_windows_executables(
     ) -> tuple[bool, bytes]:
         return True, b""
 
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr(
+        "nixie.cli.asyncio.create_subprocess_exec", fake_create_subprocess_exec
+    )
     monkeypatch.setattr("nixie.cli.wait_for_proc", fake_wait_for_proc)
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr("nixie.cli.Path.home", lambda: tmp_path)
     monkeypatch.chdir(tmp_path)
 
     def fake_which(cmd: str) -> str | None:
@@ -56,8 +57,10 @@ async def test_render_block_rejects_unexpected_executable(
     async def fail_create_subprocess_exec(*_cmd: str, **_kwargs: object) -> object:
         pytest.fail("create_subprocess_exec should not be called")
 
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", fail_create_subprocess_exec)
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "nixie.cli.asyncio.create_subprocess_exec", fail_create_subprocess_exec
+    )
+    monkeypatch.setattr("nixie.cli.Path.home", lambda: tmp_path)
     monkeypatch.chdir(tmp_path)
 
     def fake_which(cmd: str) -> str | None:


### PR DESCRIPTION
## Summary
- normalize mermaid CLI executable names so Windows `.EXE` shims such as bun-installed `mmdc` are accepted
- add a regression test ensuring `_run_mermaid_cli` allows a Windows `mmdc.EXE` path

## Testing
- make check-fmt
- make lint
- make test
- make typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d1ded1a8cc83229ce9655cbf63fa17

## Summary by Sourcery

Permit Windows mmdc CLI executables with .exe, .cmd, and .bat suffixes by normalizing the executable name before allow-listing in _run_mermaid_cli.

Enhancements:
- Normalize mermaid CLI executable names to strip Windows-specific suffixes before validation
- Allow Windows .exe, .cmd, and .bat shims for approved executables in _run_mermaid_cli

Tests:
- Add regression test to verify _run_mermaid_cli accepts a Windows mmdc.EXE path