### PR TITLE
Handle success banner encoding fallback on Windows

### DIFF
--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -110,11 +110,23 @@ ASCII_SUCCESS_BANNER: typ.Final[str] = "All diagrams validated successfully!"
 def resolve_success_banner(stream: _EncodingAwareStream | TextIO | None) -> str:
     """Return a stream-compatible success banner.
 
-    Windows runners still default to ``cp1252`` in several environments, which
-    cannot represent the emoji contained in :data:`SUCCESS_BANNER`. Attempt to
-    encode the celebratory banner with the stream's encoding and fall back to a
-    plain ASCII message if that fails. Linux environments use UTF-8 so they
-    retain the richer banner.
+    Parameters
+    ----------
+    stream : _EncodingAwareStream | TextIO | None
+        Output stream exposing an ``encoding`` attribute (e.g., ``sys.stdout``).
+
+    Returns
+    -------
+    str
+        :data:`SUCCESS_BANNER` when the stream supports it, otherwise the
+        ASCII-only fallback.
+
+    Notes
+    -----
+    Windows runners frequently default to ``cp1252`` and similar encodings that
+    cannot represent the emoji in :data:`SUCCESS_BANNER`. Probe the encoding and
+    use :data:`ASCII_SUCCESS_BANNER` whenever encoding fails or the codec is
+    unknown so callers never see ``UnicodeEncodeError``.
     """
     if stream is None:
         return SUCCESS_BANNER

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -79,9 +79,12 @@ except ModuleNotFoundError:  # pragma: no cover - test-only fallback
 if typ.TYPE_CHECKING:
     import collections.abc as cabc
 
+    TextIO = typ.TextIO
+
     class _EncodingAwareStream(typ.Protocol):
         encoding: str | None
 else:
+    TextIO = object  # type: ignore[assignment]
     _EncodingAwareStream = object
 
 LOGGER = logging.getLogger(__name__)
@@ -104,7 +107,7 @@ SUCCESS_BANNER: typ.Final[str] = "🧜‍♀️✨ All diagrams validated succes
 ASCII_SUCCESS_BANNER: typ.Final[str] = "All diagrams validated successfully!"
 
 
-def resolve_success_banner(stream: _EncodingAwareStream | None) -> str:
+def resolve_success_banner(stream: _EncodingAwareStream | TextIO | None) -> str:
     """Return a stream-compatible success banner.
 
     Windows runners still default to ``cp1252`` in several environments, which
@@ -113,7 +116,6 @@ def resolve_success_banner(stream: _EncodingAwareStream | None) -> str:
     plain ASCII message if that fails. Linux environments use UTF-8 so they
     retain the richer banner.
     """
-
     if stream is None:
         return SUCCESS_BANNER
     encoding = getattr(stream, "encoding", None)
@@ -121,7 +123,12 @@ def resolve_success_banner(stream: _EncodingAwareStream | None) -> str:
         return SUCCESS_BANNER
     try:
         SUCCESS_BANNER.encode(encoding)
-    except UnicodeEncodeError:
+    except (LookupError, TypeError, UnicodeError):
+        # ``encode`` can raise ``LookupError`` for unknown encodings and generic
+        # ``UnicodeError`` subclasses (e.g., ``UnicodeEncodeError``) when the
+        # target codec lacks emoji support. ``TypeError`` guards against streams
+        # exposing non-string ``encoding`` attributes. Fallback to ASCII in all
+        # cases so printing never propagates encoding failures to callers.
         return ASCII_SUCCESS_BANNER
     return SUCCESS_BANNER
 

--- a/nixie/cli.py
+++ b/nixie/cli.py
@@ -79,6 +79,11 @@ except ModuleNotFoundError:  # pragma: no cover - test-only fallback
 if typ.TYPE_CHECKING:
     import collections.abc as cabc
 
+    class _EncodingAwareStream(typ.Protocol):
+        encoding: str | None
+else:
+    _EncodingAwareStream = object
+
 LOGGER = logging.getLogger(__name__)
 
 BLOCK_RE = re.compile(
@@ -96,6 +101,29 @@ DEFAULT_PUPPETEER_ARGS: typ.Final[tuple[str, ...]] = (
 )
 
 SUCCESS_BANNER: typ.Final[str] = "🧜‍♀️✨ All diagrams validated successfully!"
+ASCII_SUCCESS_BANNER: typ.Final[str] = "All diagrams validated successfully!"
+
+
+def resolve_success_banner(stream: _EncodingAwareStream | None) -> str:
+    """Return a stream-compatible success banner.
+
+    Windows runners still default to ``cp1252`` in several environments, which
+    cannot represent the emoji contained in :data:`SUCCESS_BANNER`. Attempt to
+    encode the celebratory banner with the stream's encoding and fall back to a
+    plain ASCII message if that fails. Linux environments use UTF-8 so they
+    retain the richer banner.
+    """
+
+    if stream is None:
+        return SUCCESS_BANNER
+    encoding = getattr(stream, "encoding", None)
+    if not encoding:
+        return SUCCESS_BANNER
+    try:
+        SUCCESS_BANNER.encode(encoding)
+    except UnicodeEncodeError:
+        return ASCII_SUCCESS_BANNER
+    return SUCCESS_BANNER
 
 
 class UnexpectedExecutableError(ValueError):
@@ -562,7 +590,7 @@ async def main(paths: cabc.Iterable[Path], *, no_sandbox: bool = False) -> int:
                 all_success = False
             print(f"<== {path}")
         if all_success:
-            print(SUCCESS_BANNER, flush=True)
+            print(resolve_success_banner(sys.stdout), flush=True)
         return 0 if all_success else 1
 
 

--- a/tests/integration/test_cli_behavior.py
+++ b/tests/integration/test_cli_behavior.py
@@ -1,11 +1,18 @@
 """Integration tests for the CLI's high-level behaviour."""
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 
-from nixie.cli import SUCCESS_BANNER, UNKNOWN_SCHEMA, main
+from nixie.cli import (
+    ASCII_SUCCESS_BANNER,
+    SUCCESS_BANNER,
+    UNKNOWN_SCHEMA,
+    main,
+    resolve_success_banner,
+)
 
 
 class SimulatedProcessingError(ValueError):
@@ -262,3 +269,20 @@ async def test_cli_handles_file_processing_error(
     end_markers = [line for line in lines if line.startswith("<-- line ")]
     assert len(start_markers) == 1, "Expected one start marker despite the failure"
     assert len(end_markers) == 1, "Expected one end marker despite the failure"
+
+
+@pytest.mark.parametrize(
+    ("stream", "expected"),
+    [
+        (SimpleNamespace(encoding="utf-8"), SUCCESS_BANNER),
+        (SimpleNamespace(encoding="cp1252"), ASCII_SUCCESS_BANNER),
+        (SimpleNamespace(encoding=None), SUCCESS_BANNER),
+        (None, SUCCESS_BANNER),
+    ],
+)
+def test_resolve_success_banner_handles_non_utf8_streams(
+    stream: SimpleNamespace | None, expected: str
+) -> None:
+    """Prefer the celebratory banner but fall back when encoding rejects it."""
+
+    assert resolve_success_banner(stream) == expected

--- a/tests/integration/test_cli_behavior.py
+++ b/tests/integration/test_cli_behavior.py
@@ -1,5 +1,6 @@
 """Integration tests for the CLI's high-level behaviour."""
 
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -278,11 +279,60 @@ async def test_cli_handles_file_processing_error(
         (SimpleNamespace(encoding="cp1252"), ASCII_SUCCESS_BANNER),
         (SimpleNamespace(encoding=None), SUCCESS_BANNER),
         (None, SUCCESS_BANNER),
+        (SimpleNamespace(encoding="unknown-encoding"), ASCII_SUCCESS_BANNER),
     ],
 )
 def test_resolve_success_banner_handles_non_utf8_streams(
     stream: SimpleNamespace | None, expected: str
 ) -> None:
     """Prefer the celebratory banner but fall back when encoding rejects it."""
-
     assert resolve_success_banner(stream) == expected
+
+
+class _RecordingStream:
+    """In-memory text stream that exposes an ``encoding`` attribute."""
+
+    def __init__(self, encoding: str | None) -> None:
+        self.encoding = encoding
+        self._chunks: list[str] = []
+
+    def write(self, data: str) -> int:
+        self._chunks.append(data)
+        return len(data)
+
+    def flush(self) -> None:
+        # ``print`` may call ``flush``; retain compatibility without side effects.
+        return None
+
+    def getvalue(self) -> str:
+        return "".join(self._chunks)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("encoding", "expected"),
+    [
+        ("utf-8", SUCCESS_BANNER),
+        ("cp1252", ASCII_SUCCESS_BANNER),
+        ("unknown-encoding", ASCII_SUCCESS_BANNER),
+    ],
+)
+async def test_cli_emits_encoding_aware_success_banner(
+    tmp_path: Path,
+    stub_render: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
+    encoding: str,
+    expected: str,
+) -> None:
+    """Exercise ``resolve_success_banner`` through the CLI entry point."""
+    file = tmp_path / "diagram.md"
+    file.write_text("""```mermaid\nA-->B\n```""")
+
+    stream = _RecordingStream(encoding)
+    monkeypatch.setattr(sys, "stdout", stream)
+
+    exit_code = await main([file])
+
+    assert exit_code == 0
+    output = stream.getvalue().splitlines()
+    assert output[-1] == expected

--- a/tests/integration/test_cli_behavior.py
+++ b/tests/integration/test_cli_behavior.py
@@ -108,9 +108,13 @@ async def test_cli_behavior(
     assert actual == expected
 
     if expected_exit == 0:
-        assert captured.out.count(SUCCESS_BANNER) == 1
+        assert any(
+            captured.out.count(banner) == 1
+            for banner in (SUCCESS_BANNER, ASCII_SUCCESS_BANNER)
+        )
     else:
         assert captured.out.count(SUCCESS_BANNER) == 0
+        assert captured.out.count(ASCII_SUCCESS_BANNER) == 0
 
 
 @pytest.mark.asyncio
@@ -279,7 +283,7 @@ async def test_cli_handles_file_processing_error(
         (SimpleNamespace(encoding="cp1252"), ASCII_SUCCESS_BANNER),
         (SimpleNamespace(encoding=None), SUCCESS_BANNER),
         (None, SUCCESS_BANNER),
-        (SimpleNamespace(encoding="unknown-encoding"), ASCII_SUCCESS_BANNER),
+        (SimpleNamespace(encoding="not-an-encoding"), ASCII_SUCCESS_BANNER),
     ],
 )
 def test_resolve_success_banner_handles_non_utf8_streams(
@@ -314,7 +318,7 @@ class _RecordingStream:
     [
         ("utf-8", SUCCESS_BANNER),
         ("cp1252", ASCII_SUCCESS_BANNER),
-        ("unknown-encoding", ASCII_SUCCESS_BANNER),
+        ("not-an-encoding", ASCII_SUCCESS_BANNER),
     ],
 )
 async def test_cli_emits_encoding_aware_success_banner(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -13,7 +13,7 @@ from nixie.cli import ASCII_SUCCESS_BANNER, SUCCESS_BANNER, resolve_success_bann
         (SimpleNamespace(encoding="utf-8"), SUCCESS_BANNER),
         (SimpleNamespace(encoding="cp1252"), ASCII_SUCCESS_BANNER),
         (SimpleNamespace(encoding=None), SUCCESS_BANNER),
-        (SimpleNamespace(encoding="unknown-encoding"), ASCII_SUCCESS_BANNER),
+        (SimpleNamespace(encoding="not-an-encoding"), ASCII_SUCCESS_BANNER),
         (SimpleNamespace(encoding=1234), ASCII_SUCCESS_BANNER),
         (None, SUCCESS_BANNER),
     ],

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,25 @@
+"""Unit tests for helpers in :mod:`nixie.cli`."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from nixie.cli import ASCII_SUCCESS_BANNER, SUCCESS_BANNER, resolve_success_banner
+
+
+@pytest.mark.parametrize(
+    ("stream", "expected"),
+    [
+        (SimpleNamespace(encoding="utf-8"), SUCCESS_BANNER),
+        (SimpleNamespace(encoding="cp1252"), ASCII_SUCCESS_BANNER),
+        (SimpleNamespace(encoding=None), SUCCESS_BANNER),
+        (SimpleNamespace(encoding="unknown-encoding"), ASCII_SUCCESS_BANNER),
+        (SimpleNamespace(encoding=1234), ASCII_SUCCESS_BANNER),
+        (None, SUCCESS_BANNER),
+    ],
+)
+def test_resolve_success_banner_unit(
+    stream: SimpleNamespace | None, expected: str
+) -> None:
+    """Return an encoding-compatible banner for diverse stream metadata."""
+    assert resolve_success_banner(stream) == expected


### PR DESCRIPTION
## Summary
- add an ASCII fallback for the CLI success banner when stdout cannot encode emoji
- expose the helper used to pick the banner and cover it with integration tests

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d6aca53f6083228b7c79965eb82d1f

## Summary by Sourcery

Provide an ASCII fallback for the CLI success banner on environments with non-UTF-8 encodings and expose the resolution logic for integration testing

New Features:
- Add resolve_success_banner to fall back to an ASCII success banner when the output stream encoding cannot represent emojis

Enhancements:
- Invoke resolve_success_banner when printing the CLI success banner to improve cross-platform compatibility

Tests:
- Add integration tests for resolve_success_banner with various stream encodings