### PR TITLE
Rename pypi project to nixie cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ BENCH_DOCS ?= tests/fixtures/benchmark_sample
 all: check-fmt lint test ## Default target runs preflight checks
 
 clean: ## Remove build artifacts
-	rm -rf .venv dist/ *.egg-info
+	rm -rf .venv build dist/ *.egg-info
 
 build: ## install deps and build bytecode
 	@if [ -x .venv/bin/python ]; then \

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@
 
 ### From PyPI
 
-End users can install the latest release directly from PyPI:
+End users should install the latest release as a `uv` tool:
 
 ```bash
-pip install nixie-cli
+uv tool install nixie-cli
 ```
 
 This provides the `nixie` command without any development extras.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 End users can install the latest release directly from PyPI:
 
 ```bash
-pip install nixie
+pip install nixie-cli
 ```
 
 This provides the `nixie` command without any development extras.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- The PyPI distribution is now published as `nixie-cli` while keeping the
+  installed console command as `nixie`.
 - Diagram validation now runs concurrently across and within files with a
   bounded global worker limit. Output remains deterministic and ordered by file
   and diagram position.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "nixie"
+name = "nixie-cli"
 version = "0.2.0"
 description = "Validate Mermaid diagrams in Markdown files"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,10 @@ nixie = "nixie.cli:cli"
 requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-packages = ["nixie"]
+[tool.setuptools.packages.find]
+include = ["nixie"]
+exclude = ["nixie.unittests", "nixie.unittests.*"]
+namespaces = false
 
 [tool.uv]
 package = true

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-import typing as typ
+import shutil
+from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
-
-if typ.TYPE_CHECKING:
-    from pathlib import Path
 
 
 @pytest.fixture
@@ -36,3 +34,40 @@ def stub_render(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
     mock = AsyncMock(side_effect=side_effect)
     monkeypatch.setattr("nixie.cli._render_diagram", mock)
     return mock
+
+
+def _build_packaging_project(
+    destination_root: Path,
+    *,
+    include_makefile: bool = False,
+) -> Path:
+    """Copy the minimal project files needed for packaging tests."""
+    project_root = Path(__file__).resolve().parents[2]
+    build_root = destination_root / "package-copy"
+    build_root.mkdir()
+
+    names = ["pyproject.toml", "README.md", "LICENSE", "nixie"]
+    if include_makefile:
+        names.append("Makefile")
+
+    for name in names:
+        source = project_root / name
+        destination = build_root / name
+        if source.is_dir():
+            shutil.copytree(source, destination)
+        else:
+            shutil.copy2(source, destination)
+
+    return build_root
+
+
+@pytest.fixture
+def packaging_project_root(tmp_path: Path) -> Path:
+    """Provide a copied project tree for packaging tests."""
+    return _build_packaging_project(tmp_path)
+
+
+@pytest.fixture
+def packaging_project_root_with_makefile(tmp_path: Path) -> Path:
+    """Provide a copied project tree including the Makefile."""
+    return _build_packaging_project(tmp_path, include_makefile=True)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import shutil
 from pathlib import Path
 from unittest.mock import AsyncMock
+from uuid import uuid4
 
 import pytest
 
@@ -43,7 +44,7 @@ def _build_packaging_project(
 ) -> Path:
     """Copy the minimal project files needed for packaging tests."""
     project_root = Path(__file__).resolve().parents[2]
-    build_root = destination_root / "package-copy"
+    build_root = destination_root / f"package-copy-{uuid4().hex}"
     build_root.mkdir()
 
     names = ["pyproject.toml", "README.md", "LICENSE", "nixie"]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -47,9 +47,13 @@ def _build_packaging_project(
     build_root = destination_root / f"package-copy-{uuid4().hex}"
     build_root.mkdir()
 
-    names = ["pyproject.toml", "README.md", "LICENSE", "nixie"]
-    if include_makefile:
-        names.append("Makefile")
+    names = (
+        "pyproject.toml",
+        "README.md",
+        "LICENSE",
+        "nixie",
+        *(("Makefile",) if include_makefile else ()),
+    )
 
     for name in names:
         source = project_root / name

--- a/tests/integration/test_packaging.py
+++ b/tests/integration/test_packaging.py
@@ -1,0 +1,85 @@
+"""Integration tests for wheel packaging behaviour."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import zipfile
+from pathlib import Path
+
+
+def _copy_packaging_fixture(
+    destination_root: Path,
+    *,
+    include_makefile: bool = False,
+) -> Path:
+    """Copy the minimal project files needed for packaging tests."""
+    project_root = Path(__file__).resolve().parents[2]
+    build_root = destination_root / "package-copy"
+    build_root.mkdir()
+
+    names = ["pyproject.toml", "README.md", "LICENSE", "nixie"]
+    if include_makefile:
+        names.append("Makefile")
+
+    for name in names:
+        source = project_root / name
+        destination = build_root / name
+        if source.is_dir():
+            shutil.copytree(source, destination)
+        else:
+            shutil.copy2(source, destination)
+    return build_root
+
+
+def test_uv_build_excludes_unittests_from_the_wheel(tmp_path: Path) -> None:
+    """Build a wheel copy and verify that ``nixie.unittests`` is not packaged."""
+    build_root = _copy_packaging_fixture(tmp_path)
+
+    uv_executable = shutil.which("uv")
+    assert uv_executable is not None, "uv must be available to build the wheel"
+
+    result = subprocess.run(  # noqa: S603
+        [uv_executable, "build", "--wheel"],
+        cwd=build_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    combined_output = result.stdout + result.stderr
+    assert "Package 'nixie.unittests'" not in combined_output
+
+    wheel_path = next((build_root / "dist").glob("*.whl"))
+    with zipfile.ZipFile(wheel_path) as wheel_archive:
+        packaged_files = wheel_archive.namelist()
+
+    unittest_entries = [
+        packaged_file
+        for packaged_file in packaged_files
+        if packaged_file.startswith("nixie/unittests/")
+    ]
+    assert unittest_entries == []
+
+
+def test_make_clean_removes_the_build_directory(tmp_path: Path) -> None:
+    """Ensure ``make clean`` clears stale build artefacts before packaging."""
+    build_root = _copy_packaging_fixture(tmp_path, include_makefile=True)
+    stale_test_file = build_root / "build/lib/nixie/unittests/stale_test.py"
+    stale_test_file.parent.mkdir(parents=True, exist_ok=True)
+    stale_test_file.write_text("pass\n", encoding="utf-8")
+
+    make_executable = shutil.which("make")
+    assert make_executable is not None, "make must be available to clean the tree"
+
+    result = subprocess.run(  # noqa: S603
+        [make_executable, "clean"],
+        cwd=build_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert not (build_root / "build").exists()

--- a/tests/integration/test_packaging.py
+++ b/tests/integration/test_packaging.py
@@ -33,7 +33,7 @@ def _copy_packaging_fixture(
 
 
 def test_uv_build_excludes_unittests_from_the_wheel(tmp_path: Path) -> None:
-    """Build a wheel copy and verify that ``nixie.unittests`` is not packaged."""
+    """Build a wheel copy and verify packaging metadata and contents."""
     build_root = _copy_packaging_fixture(tmp_path)
 
     uv_executable = shutil.which("uv")
@@ -52,8 +52,25 @@ def test_uv_build_excludes_unittests_from_the_wheel(tmp_path: Path) -> None:
     assert "Package 'nixie.unittests'" not in combined_output
 
     wheel_path = next((build_root / "dist").glob("*.whl"))
+    assert wheel_path.name.startswith("nixie_cli-")
+
     with zipfile.ZipFile(wheel_path) as wheel_archive:
         packaged_files = wheel_archive.namelist()
+        metadata_name = next(
+            packaged_file
+            for packaged_file in packaged_files
+            if packaged_file.endswith(".dist-info/METADATA")
+        )
+        entry_points_name = next(
+            packaged_file
+            for packaged_file in packaged_files
+            if packaged_file.endswith(".dist-info/entry_points.txt")
+        )
+        metadata = wheel_archive.read(metadata_name).decode("utf-8")
+        entry_points = wheel_archive.read(entry_points_name).decode("utf-8")
+
+    assert "Name: nixie-cli" in metadata
+    assert "nixie = nixie.cli:cli" in entry_points
 
     unittest_entries = [
         packaged_file

--- a/tests/integration/test_packaging.py
+++ b/tests/integration/test_packaging.py
@@ -7,6 +7,8 @@ import subprocess
 import zipfile
 from pathlib import Path
 
+import pytest
+
 
 def _copy_packaging_fixture(
     destination_root: Path,
@@ -32,12 +34,20 @@ def _copy_packaging_fixture(
     return build_root
 
 
+def _require_executable(name: str, *, purpose: str) -> str:
+    """Return an executable path or skip when the host tool is unavailable."""
+    executable = shutil.which(name)
+    if executable is None:
+        pytest.skip(f"{name} must be available to {purpose}")
+    assert executable is not None
+    return executable
+
+
 def test_uv_build_excludes_unittests_from_the_wheel(tmp_path: Path) -> None:
     """Build a wheel copy and verify packaging metadata and contents."""
     build_root = _copy_packaging_fixture(tmp_path)
 
-    uv_executable = shutil.which("uv")
-    assert uv_executable is not None, "uv must be available to build the wheel"
+    uv_executable = _require_executable("uv", purpose="build the wheel")
 
     result = subprocess.run(  # noqa: S603
         [uv_executable, "build", "--wheel"],
@@ -86,9 +96,11 @@ def test_make_clean_removes_the_build_directory(tmp_path: Path) -> None:
     stale_test_file = build_root / "build/lib/nixie/unittests/stale_test.py"
     stale_test_file.parent.mkdir(parents=True, exist_ok=True)
     stale_test_file.write_text("pass\n", encoding="utf-8")
+    assert stale_test_file.exists(), (
+        "Expected stale test file to exist before running `make clean`"
+    )
 
-    make_executable = shutil.which("make")
-    assert make_executable is not None, "make must be available to clean the tree"
+    make_executable = _require_executable("make", purpose="clean the tree")
 
     result = subprocess.run(  # noqa: S603
         [make_executable, "clean"],

--- a/tests/integration/test_packaging.py
+++ b/tests/integration/test_packaging.py
@@ -49,12 +49,13 @@ def test_uv_build_excludes_unittests_from_the_wheel(tmp_path: Path) -> None:
 
     uv_executable = _require_executable("uv", purpose="build the wheel")
 
-    result = subprocess.run(  # noqa: S603
+    result = subprocess.run(  # noqa: S603  # Static argv in test env; shell=False.
         [uv_executable, "build", "--wheel"],
         cwd=build_root,
         check=False,
         capture_output=True,
         text=True,
+        timeout=120,
     )
 
     assert result.returncode == 0, result.stdout + result.stderr
@@ -111,12 +112,13 @@ def test_make_clean_removes_the_build_directory(tmp_path: Path) -> None:
 
     make_executable = _require_executable("make", purpose="clean the tree")
 
-    result = subprocess.run(  # noqa: S603
+    result = subprocess.run(  # noqa: S603  # Static argv in test env; shell=False.
         [make_executable, "clean"],
         cwd=build_root,
         check=False,
         capture_output=True,
         text=True,
+        timeout=120,
     )
 
     assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/integration/test_packaging.py
+++ b/tests/integration/test_packaging.py
@@ -61,21 +61,30 @@ def test_uv_build_excludes_unittests_from_the_wheel(tmp_path: Path) -> None:
     combined_output = result.stdout + result.stderr
     assert "Package 'nixie.unittests'" not in combined_output
 
-    wheel_path = next((build_root / "dist").glob("*.whl"))
+    wheel_path = next((build_root / "dist").glob("*.whl"), None)
+    assert wheel_path is not None, "wheel file not found"
     assert wheel_path.name.startswith("nixie_cli-")
 
     with zipfile.ZipFile(wheel_path) as wheel_archive:
         packaged_files = wheel_archive.namelist()
         metadata_name = next(
-            packaged_file
-            for packaged_file in packaged_files
-            if packaged_file.endswith(".dist-info/METADATA")
+            (
+                packaged_file
+                for packaged_file in packaged_files
+                if packaged_file.endswith(".dist-info/METADATA")
+            ),
+            None,
         )
+        assert metadata_name is not None, "METADATA file not found in wheel"
         entry_points_name = next(
-            packaged_file
-            for packaged_file in packaged_files
-            if packaged_file.endswith(".dist-info/entry_points.txt")
+            (
+                packaged_file
+                for packaged_file in packaged_files
+                if packaged_file.endswith(".dist-info/entry_points.txt")
+            ),
+            None,
         )
+        assert entry_points_name is not None, "entry_points.txt not found in wheel"
         metadata = wheel_archive.read(metadata_name).decode("utf-8")
         entry_points = wheel_archive.read(entry_points_name).decode("utf-8")
 

--- a/tests/integration/test_packaging.py
+++ b/tests/integration/test_packaging.py
@@ -4,34 +4,13 @@ from __future__ import annotations
 
 import shutil
 import subprocess
+import typing as typ
 import zipfile
-from pathlib import Path
 
 import pytest
 
-
-def _copy_packaging_fixture(
-    destination_root: Path,
-    *,
-    include_makefile: bool = False,
-) -> Path:
-    """Copy the minimal project files needed for packaging tests."""
-    project_root = Path(__file__).resolve().parents[2]
-    build_root = destination_root / "package-copy"
-    build_root.mkdir()
-
-    names = ["pyproject.toml", "README.md", "LICENSE", "nixie"]
-    if include_makefile:
-        names.append("Makefile")
-
-    for name in names:
-        source = project_root / name
-        destination = build_root / name
-        if source.is_dir():
-            shutil.copytree(source, destination)
-        else:
-            shutil.copy2(source, destination)
-    return build_root
+if typ.TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _require_executable(name: str, *, purpose: str) -> str:
@@ -43,9 +22,11 @@ def _require_executable(name: str, *, purpose: str) -> str:
     return executable
 
 
-def test_uv_build_excludes_unittests_from_the_wheel(tmp_path: Path) -> None:
+def test_uv_build_excludes_unittests_from_the_wheel(
+    packaging_project_root: Path,
+) -> None:
     """Build a wheel copy and verify packaging metadata and contents."""
-    build_root = _copy_packaging_fixture(tmp_path)
+    build_root = packaging_project_root
 
     uv_executable = _require_executable("uv", purpose="build the wheel")
 
@@ -60,11 +41,15 @@ def test_uv_build_excludes_unittests_from_the_wheel(tmp_path: Path) -> None:
 
     assert result.returncode == 0, result.stdout + result.stderr
     combined_output = result.stdout + result.stderr
-    assert "Package 'nixie.unittests'" not in combined_output
+    assert "Package 'nixie.unittests'" not in combined_output, (
+        f"Expected build output to exclude `nixie.unittests`, got: {combined_output!r}"
+    )
 
     wheel_path = next((build_root / "dist").glob("*.whl"), None)
     assert wheel_path is not None, "wheel file not found"
-    assert wheel_path.name.startswith("nixie_cli-")
+    assert wheel_path.name.startswith("nixie_cli-"), (
+        f"Expected wheel_path.name to start with 'nixie_cli-', got: {wheel_path.name!r}"
+    )
 
     with zipfile.ZipFile(wheel_path) as wheel_archive:
         packaged_files = wheel_archive.namelist()
@@ -89,20 +74,28 @@ def test_uv_build_excludes_unittests_from_the_wheel(tmp_path: Path) -> None:
         metadata = wheel_archive.read(metadata_name).decode("utf-8")
         entry_points = wheel_archive.read(entry_points_name).decode("utf-8")
 
-    assert "Name: nixie-cli" in metadata
-    assert "nixie = nixie.cli:cli" in entry_points
+    assert "Name: nixie-cli" in metadata, (
+        f"Expected 'Name: nixie-cli' in metadata, got: {metadata!r}"
+    )
+    assert "nixie = nixie.cli:cli" in entry_points, (
+        f"Expected 'nixie = nixie.cli:cli' in entry_points, got: {entry_points!r}"
+    )
 
     unittest_entries = [
         packaged_file
         for packaged_file in packaged_files
         if packaged_file.startswith("nixie/unittests/")
     ]
-    assert unittest_entries == []
+    assert unittest_entries == [], (
+        f"Expected unittest_entries to be empty, got: {unittest_entries!r}"
+    )
 
 
-def test_make_clean_removes_the_build_directory(tmp_path: Path) -> None:
+def test_make_clean_removes_the_build_directory(
+    packaging_project_root_with_makefile: Path,
+) -> None:
     """Ensure ``make clean`` clears stale build artefacts before packaging."""
-    build_root = _copy_packaging_fixture(tmp_path, include_makefile=True)
+    build_root = packaging_project_root_with_makefile
     stale_test_file = build_root / "build/lib/nixie/unittests/stale_test.py"
     stale_test_file.parent.mkdir(parents=True, exist_ok=True)
     stale_test_file.write_text("pass\n", encoding="utf-8")
@@ -122,4 +115,7 @@ def test_make_clean_removes_the_build_directory(tmp_path: Path) -> None:
     )
 
     assert result.returncode == 0, result.stdout + result.stderr
-    assert not (build_root / "build").exists()
+    build_dir = build_root / "build"
+    assert not build_dir.exists(), (
+        f"Expected build_dir to be removed by `make clean`, got: {build_dir!s}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -72,7 +72,7 @@ wheels = [
 ]
 
 [[package]]
-name = "nixie"
+name = "nixie-cli"
 version = "0.2.0"
 source = { editable = "." }
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -73,7 +73,7 @@ wheels = [
 
 [[package]]
 name = "nixie"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "pathspec" },


### PR DESCRIPTION
## Summary by Sourcery

Rename the packaged PyPI distribution to `nixie-cli` and tighten packaging so unit tests and stale build artifacts are excluded from published wheels.

Enhancements:
- Adjust setuptools package discovery to include the main package but exclude test modules from the built wheel.

Build:
- Rename the project artifact to `nixie-cli` in packaging metadata and ensure `make clean` removes the build directory before packaging.

Documentation:
- Update README and changelog to describe installing the tool from PyPI as `nixie-cli` while keeping the `nixie` CLI command name.

Tests:
- Add integration tests verifying wheel metadata, exclusion of unit tests from the wheel, and proper cleanup of the build directory via `make clean`.